### PR TITLE
Hide warnings as much as possible

### DIFF
--- a/.depend
+++ b/.depend
@@ -1,137 +1,50 @@
 libs/ocplib-compat/string-compat/stringCompat.cmo :
 libs/ocplib-compat/string-compat/stringCompat.cmx :
-libs/ocplib-debug/debugVerbosity.cmo : libs/ocplib-debug/debugVerbosity.cmi
-libs/ocplib-debug/debugVerbosity.cmx : libs/ocplib-debug/debugVerbosity.cmi
+libs/ocplib-config/pythonConfig.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-file/file.cmi libs/ocplib-config/pythonConfig.cmi
+libs/ocplib-config/pythonConfig.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-file/file.cmx libs/ocplib-config/pythonConfig.cmi
+libs/ocplib-config/pythonConfig.cmi : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-file/file.cmi
+libs/ocplib-config/simpleConfig.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-config/simpleConfigTypes.cmo \
+    libs/ocplib-config/simpleConfigOCaml.cmi libs/ocplib-lang/intMap.cmi \
+    libs/ocplib-file/file.cmi libs/ocplib-config/simpleConfig.cmi
+libs/ocplib-config/simpleConfig.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-config/simpleConfigTypes.cmx \
+    libs/ocplib-config/simpleConfigOCaml.cmx libs/ocplib-lang/intMap.cmx \
+    libs/ocplib-file/file.cmx libs/ocplib-config/simpleConfig.cmi
+libs/ocplib-config/simpleConfig.cmi : libs/ocplib-lang/intMap.cmi \
+    libs/ocplib-file/file.cmi
+libs/ocplib-config/simpleConfigOCaml.cmo : \
+    libs/ocplib-config/simpleConfigTypes.cmo libs/ocplib-lang/ocpString.cmi \
+    libs/ocplib-config/simpleConfigOCaml.cmi
+libs/ocplib-config/simpleConfigOCaml.cmx : \
+    libs/ocplib-config/simpleConfigTypes.cmx libs/ocplib-lang/ocpString.cmx \
+    libs/ocplib-config/simpleConfigOCaml.cmi
+libs/ocplib-config/simpleConfigOCaml.cmi : \
+    libs/ocplib-config/simpleConfigTypes.cmo libs/ocplib-file/file.cmi
+libs/ocplib-config/simpleConfigTypes.cmo : libs/ocplib-file/file.cmi
+libs/ocplib-config/simpleConfigTypes.cmx : libs/ocplib-file/file.cmx
 libs/ocplib-debug/debugTyperex.cmo : libs/ocplib-debug/debugTyperex.cmi
 libs/ocplib-debug/debugTyperex.cmx : libs/ocplib-debug/debugTyperex.cmi
-libs/ocplib-lang/ocpPervasives.cmo : libs/ocplib-lang/ocpPervasives.cmi
-libs/ocplib-lang/ocpPervasives.cmx : libs/ocplib-lang/ocpPervasives.cmi
-libs/ocplib-lang/ocpList.cmo : libs/ocplib-lang/ocpList.cmi
-libs/ocplib-lang/ocpList.cmx : libs/ocplib-lang/ocpList.cmi
-libs/ocplib-lang/ocpString.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocpList.cmi libs/ocplib-lang/ocpString.cmi
-libs/ocplib-lang/ocpString.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocpList.cmx libs/ocplib-lang/ocpString.cmi
-libs/ocplib-lang/ocpStream.cmo : libs/ocplib-lang/ocpString.cmi \
-    libs/ocplib-lang/ocpStream.cmi
-libs/ocplib-lang/ocpStream.cmx : libs/ocplib-lang/ocpString.cmx \
-    libs/ocplib-lang/ocpStream.cmi
-libs/ocplib-lang/ocpGenlex.cmo : libs/ocplib-lang/ocpString.cmi \
-    libs/ocplib-lang/ocpStream.cmi libs/ocplib-lang/ocpGenlex.cmi
-libs/ocplib-lang/ocpGenlex.cmx : libs/ocplib-lang/ocpString.cmx \
-    libs/ocplib-lang/ocpStream.cmx libs/ocplib-lang/ocpGenlex.cmi
-libs/ocplib-lang/ocpHashtbl.cmo : libs/ocplib-lang/ocpHashtbl.cmi
-libs/ocplib-lang/ocpHashtbl.cmx : libs/ocplib-lang/ocpHashtbl.cmi
-libs/ocplib-lang/ocpDigest.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocpDigest.cmi
-libs/ocplib-lang/ocpDigest.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocpDigest.cmi
-libs/ocplib-lang/ocpArray.cmo : libs/ocplib-lang/ocpArray.cmi
-libs/ocplib-lang/ocpArray.cmx : libs/ocplib-lang/ocpArray.cmi
-libs/ocplib-lang/option.cmo : libs/ocplib-lang/option.cmi
-libs/ocplib-lang/option.cmx : libs/ocplib-lang/option.cmi
-libs/ocplib-lang/intMap.cmo : libs/ocplib-lang/intMap.cmi
-libs/ocplib-lang/intMap.cmx : libs/ocplib-lang/intMap.cmi
-libs/ocplib-lang/intSet.cmo : libs/ocplib-lang/intSet.cmi
-libs/ocplib-lang/intSet.cmx : libs/ocplib-lang/intSet.cmi
-libs/ocplib-lang/stringMap.cmo : libs/ocplib-lang/stringMap.cmi
-libs/ocplib-lang/stringMap.cmx : libs/ocplib-lang/stringMap.cmi
-libs/ocplib-lang/stringSet.cmo : libs/ocplib-lang/stringSet.cmi
-libs/ocplib-lang/stringSet.cmx : libs/ocplib-lang/stringSet.cmi
-libs/ocplib-lang/toposort.cmo : libs/ocplib-lang/toposort.cmi
-libs/ocplib-lang/toposort.cmx : libs/ocplib-lang/toposort.cmi
-libs/ocplib-lang/linearToposort.cmo : libs/ocplib-lang/intMap.cmi \
-    libs/ocplib-debug/debugVerbosity.cmi libs/ocplib-lang/linearToposort.cmi
-libs/ocplib-lang/linearToposort.cmx : libs/ocplib-lang/intMap.cmx \
-    libs/ocplib-debug/debugVerbosity.cmx libs/ocplib-lang/linearToposort.cmi
-libs/ocplib-lang/ocamllexer.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocamllexer.cmi
-libs/ocplib-lang/ocamllexer.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocamllexer.cmi
-libs/ocplib-lang/trie.cmo : libs/ocplib-lang/trie.cmi
-libs/ocplib-lang/trie.cmx : libs/ocplib-lang/trie.cmi
-libs/ocplib-lang/ocpLang.cmo : libs/ocplib-lang/ocpString.cmi \
-    libs/ocplib-lang/ocpStream.cmi libs/ocplib-lang/ocpPervasives.cmi \
-    libs/ocplib-lang/ocpList.cmi libs/ocplib-lang/ocpHashtbl.cmi \
-    libs/ocplib-lang/ocpGenlex.cmi libs/ocplib-lang/ocpDigest.cmi \
-    libs/ocplib-lang/ocpLang.cmi
-libs/ocplib-lang/ocpLang.cmx : libs/ocplib-lang/ocpString.cmx \
-    libs/ocplib-lang/ocpStream.cmx libs/ocplib-lang/ocpPervasives.cmx \
-    libs/ocplib-lang/ocpList.cmx libs/ocplib-lang/ocpHashtbl.cmx \
-    libs/ocplib-lang/ocpGenlex.cmx libs/ocplib-lang/ocpDigest.cmx \
-    libs/ocplib-lang/ocpLang.cmi
-libs/ocplib-lang/stringSubst.cmo : libs/ocplib-lang/stringSubst.cmi
-libs/ocplib-lang/stringSubst.cmx : libs/ocplib-lang/stringSubst.cmi
-libs/ocplib-lang/manpage.cmo : libs/ocplib-lang/manpage.cmi
-libs/ocplib-lang/manpage.cmx : libs/ocplib-lang/manpage.cmi
-libs/ocplib-lang/stringTemplate.cmo : libs/ocplib-lang/stringSubst.cmi \
-    libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/stringTemplate.cmi
-libs/ocplib-lang/stringTemplate.cmx : libs/ocplib-lang/stringSubst.cmx \
-    libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/stringTemplate.cmi
-libs/ocplib-lang/reentrantBuffers.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/reentrantBuffers.cmi
-libs/ocplib-lang/reentrantBuffers.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/reentrantBuffers.cmi
-libs/ocplib-unix/minUnix.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-unix/minUnix.cmi
-libs/ocplib-unix/minUnix.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-unix/minUnix.cmi
-libs/ocplib-unix/onlyUnix.cmo : libs/ocplib-unix/minUnix.cmi \
-    libs/ocplib-unix/onlyUnix.cmi
-libs/ocplib-unix/onlyUnix.cmx : libs/ocplib-unix/minUnix.cmx \
-    libs/ocplib-unix/onlyUnix.cmi
-libs/ocplib-unix/onlyWin32.cmo : libs/ocplib-unix/minUnix.cmi \
-    libs/ocplib-unix/onlyWin32.cmi
-libs/ocplib-unix/onlyWin32.cmx : libs/ocplib-unix/minUnix.cmx \
-    libs/ocplib-unix/onlyWin32.cmi
-libs/ocplib-file/fileSig.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-unix/minUnix.cmi
-libs/ocplib-file/fileSig.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-unix/minUnix.cmx
-libs/ocplib-file/fileOS.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-file/fileOS.cmi
-libs/ocplib-file/fileOS.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-file/fileOS.cmi
-libs/ocplib-file/fileChannel.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/reentrantBuffers.cmi libs/ocplib-lang/ocpArray.cmi \
-    libs/ocplib-file/fileOS.cmi libs/ocplib-file/fileChannel.cmi
-libs/ocplib-file/fileChannel.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/reentrantBuffers.cmx libs/ocplib-lang/ocpArray.cmx \
-    libs/ocplib-file/fileOS.cmx libs/ocplib-file/fileChannel.cmi
-libs/ocplib-file/fileString.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocpString.cmi libs/ocplib-lang/ocpList.cmi \
-    libs/ocplib-unix/minUnix.cmi libs/ocplib-file/fileChannel.cmi \
-    libs/ocplib-file/fileString.cmi
-libs/ocplib-file/fileString.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocpString.cmx libs/ocplib-lang/ocpList.cmx \
-    libs/ocplib-unix/minUnix.cmx libs/ocplib-file/fileChannel.cmx \
-    libs/ocplib-file/fileString.cmi
-libs/ocplib-file/fileLines.cmo : libs/ocplib-file/fileString.cmi \
-    libs/ocplib-file/fileLines.cmi
-libs/ocplib-file/fileLines.cmx : libs/ocplib-file/fileString.cmx \
-    libs/ocplib-file/fileLines.cmi
+libs/ocplib-debug/debugTyperex.cmi :
+libs/ocplib-debug/debugVerbosity.cmo : libs/ocplib-debug/debugVerbosity.cmi
+libs/ocplib-debug/debugVerbosity.cmx : libs/ocplib-debug/debugVerbosity.cmi
+libs/ocplib-debug/debugVerbosity.cmi :
+libs/ocplib-file/dir.cmo : libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-unix/minUnix.cmi libs/ocplib-file/file.cmi \
+    libs/ocplib-file/dir.cmi
+libs/ocplib-file/dir.cmx : libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-unix/minUnix.cmx libs/ocplib-file/file.cmx \
+    libs/ocplib-file/dir.cmi
+libs/ocplib-file/dir.cmi : libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-file/file.cmi
 libs/ocplib-file/file.cmo : \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
     libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
@@ -144,26 +57,160 @@ libs/ocplib-file/file.cmx : \
     libs/ocplib-file/fileString.cmx libs/ocplib-file/fileOS.cmx \
     libs/ocplib-file/fileLines.cmx libs/ocplib-file/fileChannel.cmx \
     libs/ocplib-file/file.cmi
-libs/ocplib-file/dir.cmo : libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-unix/minUnix.cmi libs/ocplib-file/file.cmi \
-    libs/ocplib-file/dir.cmi
-libs/ocplib-file/dir.cmx : libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-unix/minUnix.cmx libs/ocplib-file/file.cmx \
-    libs/ocplib-file/dir.cmi
+libs/ocplib-file/file.cmi : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-file/fileSig.cmo
+libs/ocplib-file/fileChannel.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/reentrantBuffers.cmi libs/ocplib-lang/ocpArray.cmi \
+    libs/ocplib-file/fileOS.cmi libs/ocplib-file/fileChannel.cmi
+libs/ocplib-file/fileChannel.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/reentrantBuffers.cmx libs/ocplib-lang/ocpArray.cmx \
+    libs/ocplib-file/fileOS.cmx libs/ocplib-file/fileChannel.cmi
+libs/ocplib-file/fileChannel.cmi : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-file/fileSig.cmo
+libs/ocplib-file/fileLines.cmo : libs/ocplib-file/fileString.cmi \
+    libs/ocplib-file/fileLines.cmi
+libs/ocplib-file/fileLines.cmx : libs/ocplib-file/fileString.cmx \
+    libs/ocplib-file/fileLines.cmi
+libs/ocplib-file/fileLines.cmi :
+libs/ocplib-file/fileOS.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-file/fileOS.cmi
+libs/ocplib-file/fileOS.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-file/fileOS.cmi
+libs/ocplib-file/fileOS.cmi :
+libs/ocplib-file/fileSig.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-unix/minUnix.cmi
+libs/ocplib-file/fileSig.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-unix/minUnix.cmx
+libs/ocplib-file/fileString.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/ocpString.cmi libs/ocplib-lang/ocpList.cmi \
+    libs/ocplib-unix/minUnix.cmi libs/ocplib-file/fileChannel.cmi \
+    libs/ocplib-file/fileString.cmi
+libs/ocplib-file/fileString.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/ocpString.cmx libs/ocplib-lang/ocpList.cmx \
+    libs/ocplib-unix/minUnix.cmx libs/ocplib-file/fileChannel.cmx \
+    libs/ocplib-file/fileString.cmi
+libs/ocplib-file/fileString.cmi : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-file/fileSig.cmo
+libs/ocplib-lang/intMap.cmo : libs/ocplib-lang/intMap.cmi
+libs/ocplib-lang/intMap.cmx : libs/ocplib-lang/intMap.cmi
+libs/ocplib-lang/intMap.cmi :
+libs/ocplib-lang/intSet.cmo : libs/ocplib-lang/intSet.cmi
+libs/ocplib-lang/intSet.cmx : libs/ocplib-lang/intSet.cmi
+libs/ocplib-lang/intSet.cmi :
+libs/ocplib-lang/linearToposort.cmo : libs/ocplib-lang/intMap.cmi \
+    libs/ocplib-lang/linearToposort.cmi
+libs/ocplib-lang/linearToposort.cmx : libs/ocplib-lang/intMap.cmx \
+    libs/ocplib-lang/linearToposort.cmi
+libs/ocplib-lang/linearToposort.cmi :
+libs/ocplib-lang/manpage.cmo : libs/ocplib-lang/manpage.cmi
+libs/ocplib-lang/manpage.cmx : libs/ocplib-lang/manpage.cmi
+libs/ocplib-lang/manpage.cmi :
+libs/ocplib-lang/ocamllexer.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/ocamllexer.cmi
+libs/ocplib-lang/ocamllexer.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/ocamllexer.cmi
+libs/ocplib-lang/ocamllexer.cmi :
+libs/ocplib-lang/ocpArray.cmo : libs/ocplib-lang/ocpArray.cmi
+libs/ocplib-lang/ocpArray.cmx : libs/ocplib-lang/ocpArray.cmi
+libs/ocplib-lang/ocpArray.cmi :
+libs/ocplib-lang/ocpDigest.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/ocpDigest.cmi
+libs/ocplib-lang/ocpDigest.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/ocpDigest.cmi
+libs/ocplib-lang/ocpDigest.cmi :
+libs/ocplib-lang/ocpGenlex.cmo : libs/ocplib-lang/ocpGenlex.cmi
+libs/ocplib-lang/ocpGenlex.cmx : libs/ocplib-lang/ocpGenlex.cmi
+libs/ocplib-lang/ocpGenlex.cmi :
+libs/ocplib-lang/ocpHashtbl.cmo : libs/ocplib-lang/ocpHashtbl.cmi
+libs/ocplib-lang/ocpHashtbl.cmx : libs/ocplib-lang/ocpHashtbl.cmi
+libs/ocplib-lang/ocpHashtbl.cmi :
+libs/ocplib-lang/ocpLang.cmo : libs/ocplib-lang/ocpString.cmi \
+    libs/ocplib-lang/ocpStream.cmi libs/ocplib-lang/ocpPervasives.cmi \
+    libs/ocplib-lang/ocpList.cmi libs/ocplib-lang/ocpHashtbl.cmi \
+    libs/ocplib-lang/ocpGenlex.cmi libs/ocplib-lang/ocpDigest.cmi \
+    libs/ocplib-lang/ocpLang.cmi
+libs/ocplib-lang/ocpLang.cmx : libs/ocplib-lang/ocpString.cmx \
+    libs/ocplib-lang/ocpStream.cmx libs/ocplib-lang/ocpPervasives.cmx \
+    libs/ocplib-lang/ocpList.cmx libs/ocplib-lang/ocpHashtbl.cmx \
+    libs/ocplib-lang/ocpGenlex.cmx libs/ocplib-lang/ocpDigest.cmx \
+    libs/ocplib-lang/ocpLang.cmi
+libs/ocplib-lang/ocpLang.cmi : libs/ocplib-lang/ocpString.cmi \
+    libs/ocplib-lang/ocpStream.cmi libs/ocplib-lang/ocpPervasives.cmi \
+    libs/ocplib-lang/ocpList.cmi libs/ocplib-lang/ocpHashtbl.cmi \
+    libs/ocplib-lang/ocpGenlex.cmi libs/ocplib-lang/ocpDigest.cmi
+libs/ocplib-lang/ocpList.cmo : libs/ocplib-lang/ocpList.cmi
+libs/ocplib-lang/ocpList.cmx : libs/ocplib-lang/ocpList.cmi
+libs/ocplib-lang/ocpList.cmi :
+libs/ocplib-lang/ocpPervasives.cmo : libs/ocplib-lang/ocpPervasives.cmi
+libs/ocplib-lang/ocpPervasives.cmx : libs/ocplib-lang/ocpPervasives.cmi
+libs/ocplib-lang/ocpPervasives.cmi :
+libs/ocplib-lang/ocpStream.cmo : libs/ocplib-lang/ocpString.cmi \
+    libs/ocplib-lang/ocpStream.cmi
+libs/ocplib-lang/ocpStream.cmx : libs/ocplib-lang/ocpString.cmx \
+    libs/ocplib-lang/ocpStream.cmi
+libs/ocplib-lang/ocpStream.cmi :
+libs/ocplib-lang/ocpString.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/ocpList.cmi libs/ocplib-lang/ocpString.cmi
+libs/ocplib-lang/ocpString.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/ocpList.cmx libs/ocplib-lang/ocpString.cmi
+libs/ocplib-lang/ocpString.cmi :
+libs/ocplib-lang/option.cmo : libs/ocplib-lang/option.cmi
+libs/ocplib-lang/option.cmx : libs/ocplib-lang/option.cmi
+libs/ocplib-lang/option.cmi :
+libs/ocplib-lang/reentrantBuffers.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/reentrantBuffers.cmi
+libs/ocplib-lang/reentrantBuffers.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/reentrantBuffers.cmi
+libs/ocplib-lang/reentrantBuffers.cmi : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo
+libs/ocplib-lang/stringMap.cmo : libs/ocplib-lang/stringMap.cmi
+libs/ocplib-lang/stringMap.cmx : libs/ocplib-lang/stringMap.cmi
+libs/ocplib-lang/stringMap.cmi :
+libs/ocplib-lang/stringSet.cmo : libs/ocplib-lang/stringSet.cmi
+libs/ocplib-lang/stringSet.cmx : libs/ocplib-lang/stringSet.cmi
+libs/ocplib-lang/stringSet.cmi :
+libs/ocplib-lang/stringSubst.cmo : libs/ocplib-lang/stringSubst.cmi
+libs/ocplib-lang/stringSubst.cmx : libs/ocplib-lang/stringSubst.cmi
+libs/ocplib-lang/stringSubst.cmi :
+libs/ocplib-lang/stringTemplate.cmo : libs/ocplib-lang/stringSubst.cmi \
+    libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/stringTemplate.cmi
+libs/ocplib-lang/stringTemplate.cmx : libs/ocplib-lang/stringSubst.cmx \
+    libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/stringTemplate.cmi
+libs/ocplib-lang/stringTemplate.cmi :
+libs/ocplib-lang/toposort.cmo : libs/ocplib-lang/toposort.cmi
+libs/ocplib-lang/toposort.cmx : libs/ocplib-lang/toposort.cmi
+libs/ocplib-lang/toposort.cmi :
+libs/ocplib-lang/trie.cmo : libs/ocplib-lang/trie.cmi
+libs/ocplib-lang/trie.cmx : libs/ocplib-lang/trie.cmi
+libs/ocplib-lang/trie.cmi :
 libs/ocplib-system/date.cmo : libs/ocplib-unix/minUnix.cmi \
     libs/ocplib-system/date.cmi
 libs/ocplib-system/date.cmx : libs/ocplib-unix/minUnix.cmx \
     libs/ocplib-system/date.cmi
-libs/ocplib-system/ocpUnix.cmo : libs/ocplib-lang/ocpLang.cmi \
-    libs/ocplib-unix/minUnix.cmi libs/ocplib-file/fileString.cmi \
-    libs/ocplib-system/ocpUnix.cmi
-libs/ocplib-system/ocpUnix.cmx : libs/ocplib-lang/ocpLang.cmx \
-    libs/ocplib-unix/minUnix.cmx libs/ocplib-file/fileString.cmx \
-    libs/ocplib-system/ocpUnix.cmi
-libs/ocplib-system/ocpFilename.cmo : libs/ocplib-lang/ocpLang.cmi \
-    libs/ocplib-system/ocpFilename.cmi
-libs/ocplib-system/ocpFilename.cmx : libs/ocplib-lang/ocpLang.cmx \
-    libs/ocplib-system/ocpFilename.cmi
+libs/ocplib-system/date.cmi : libs/ocplib-unix/minUnix.cmi
 libs/ocplib-system/debug.cmo : \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
     libs/ocplib-lang/option.cmi libs/ocplib-system/date.cmi \
@@ -172,6 +219,7 @@ libs/ocplib-system/debug.cmx : \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
     libs/ocplib-lang/option.cmx libs/ocplib-system/date.cmx \
     libs/ocplib-system/debug.cmi
+libs/ocplib-system/debug.cmi :
 libs/ocplib-system/fileTemplate.cmo : libs/ocplib-lang/stringTemplate.cmi \
     libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
@@ -184,212 +232,235 @@ libs/ocplib-system/fileTemplate.cmx : libs/ocplib-lang/stringTemplate.cmx \
     libs/ocplib-lang/ocpString.cmx libs/ocplib-lang/ocpGenlex.cmx \
     libs/ocplib-file/fileString.cmx libs/ocplib-file/fileLines.cmx \
     libs/ocplib-system/fileTemplate.cmi
-libs/ocplib-config/pythonConfig.cmo : libs/ocplib-lang/stringMap.cmi \
+libs/ocplib-system/fileTemplate.cmi :
+libs/ocplib-system/ocpFilename.cmo : libs/ocplib-lang/ocpLang.cmi \
+    libs/ocplib-system/ocpFilename.cmi
+libs/ocplib-system/ocpFilename.cmx : libs/ocplib-lang/ocpLang.cmx \
+    libs/ocplib-system/ocpFilename.cmi
+libs/ocplib-system/ocpFilename.cmi :
+libs/ocplib-system/ocpUnix.cmo : libs/ocplib-lang/ocpLang.cmi \
+    libs/ocplib-unix/minUnix.cmi libs/ocplib-file/fileString.cmi \
+    libs/ocplib-system/ocpUnix.cmi
+libs/ocplib-system/ocpUnix.cmx : libs/ocplib-lang/ocpLang.cmx \
+    libs/ocplib-unix/minUnix.cmx libs/ocplib-file/fileString.cmx \
+    libs/ocplib-system/ocpUnix.cmi
+libs/ocplib-system/ocpUnix.cmi :
+libs/ocplib-unix/minUnix.cmo : \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-file/file.cmi libs/ocplib-config/pythonConfig.cmi
-libs/ocplib-config/pythonConfig.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-unix/minUnix.cmi
+libs/ocplib-unix/minUnix.cmx : \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-file/file.cmx libs/ocplib-config/pythonConfig.cmi
-libs/ocplib-config/simpleConfigTypes.cmo : libs/ocplib-file/file.cmi
-libs/ocplib-config/simpleConfigTypes.cmx : libs/ocplib-file/file.cmx
-libs/ocplib-config/simpleConfigOCaml.cmo : \
-    libs/ocplib-config/simpleConfigTypes.cmo libs/ocplib-lang/ocpString.cmi \
-    libs/ocplib-config/simpleConfigOCaml.cmi
-libs/ocplib-config/simpleConfigOCaml.cmx : \
-    libs/ocplib-config/simpleConfigTypes.cmx libs/ocplib-lang/ocpString.cmx \
-    libs/ocplib-config/simpleConfigOCaml.cmi
-libs/ocplib-config/simpleConfig.cmo : \
+    libs/ocplib-unix/minUnix.cmi
+libs/ocplib-unix/minUnix.cmi :
+libs/ocplib-unix/onlyUnix.cmo : libs/ocplib-unix/minUnix.cmi \
+    libs/ocplib-unix/onlyUnix.cmi
+libs/ocplib-unix/onlyUnix.cmx : libs/ocplib-unix/minUnix.cmx \
+    libs/ocplib-unix/onlyUnix.cmi
+libs/ocplib-unix/onlyUnix.cmi : libs/ocplib-unix/minUnix.cmi
+libs/ocplib-unix/onlyWin32.cmo : libs/ocplib-unix/minUnix.cmi \
+    libs/ocplib-unix/onlyWin32.cmi
+libs/ocplib-unix/onlyWin32.cmx : libs/ocplib-unix/minUnix.cmx \
+    libs/ocplib-unix/onlyWin32.cmi
+libs/ocplib-unix/onlyWin32.cmi : libs/ocplib-unix/minUnix.cmi
+tools/ocp-build/buildActionBuild.cmo : libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-config/simpleConfigTypes.cmo \
-    libs/ocplib-config/simpleConfigOCaml.cmi libs/ocplib-lang/intMap.cmi \
-    libs/ocplib-file/file.cmi libs/ocplib-config/simpleConfig.cmi
-libs/ocplib-config/simpleConfig.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-config/simpleConfigTypes.cmx \
-    libs/ocplib-config/simpleConfigOCaml.cmx libs/ocplib-lang/intMap.cmx \
-    libs/ocplib-file/file.cmx libs/ocplib-config/simpleConfig.cmi
-tools/ocp-build/logger.cmo :
-tools/ocp-build/logger.cmx :
-tools/ocp-build/buildMisc.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-unix/onlyWin32.cmi libs/ocplib-unix/onlyUnix.cmi \
-    libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
-    libs/ocplib-file/fileString.cmi
-tools/ocp-build/buildMisc.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-unix/onlyWin32.cmx libs/ocplib-unix/onlyUnix.cmx \
-    libs/ocplib-lang/ocpString.cmx libs/ocplib-unix/minUnix.cmx \
-    libs/ocplib-file/fileString.cmx
-tools/ocp-build/buildMtime.cmo : libs/ocplib-lang/ocpDigest.cmi \
-    libs/ocplib-unix/minUnix.cmi tools/ocp-build/buildMtime.cmi
-tools/ocp-build/buildMtime.cmx : libs/ocplib-lang/ocpDigest.cmx \
-    libs/ocplib-unix/minUnix.cmx tools/ocp-build/buildMtime.cmi
-tools/ocp-build/buildScanner.cmo : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-file/fileString.cmi tools/ocp-build/buildScanner.cmi
-tools/ocp-build/buildScanner.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-file/fileString.cmx tools/ocp-build/buildScanner.cmi
-tools/ocp-build/buildSubst.cmo : libs/ocplib-lang/stringSubst.cmi \
-    libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
-    tools/ocp-build/buildSubst.cmi
-tools/ocp-build/buildSubst.cmx : libs/ocplib-lang/stringSubst.cmx \
-    libs/ocplib-lang/ocpString.cmx libs/ocplib-unix/minUnix.cmx \
-    tools/ocp-build/buildSubst.cmi
-tools/ocp-build/buildFind.cmo : tools/ocp-build/buildFind.cmi
-tools/ocp-build/buildFind.cmx : tools/ocp-build/buildFind.cmi
-tools/ocp-build/buildTerm.cmo : libs/ocplib-lang/ocpString.cmi \
-    libs/ocplib-unix/minUnix.cmi tools/ocp-build/buildMisc.cmo \
-    tools/ocp-build/buildTerm.cmi
-tools/ocp-build/buildTerm.cmx : libs/ocplib-lang/ocpString.cmx \
-    libs/ocplib-unix/minUnix.cmx tools/ocp-build/buildMisc.cmx \
-    tools/ocp-build/buildTerm.cmi
-tools/ocp-build/ocamldot.cmo : tools/ocp-build/ocamldot.cmi
-tools/ocp-build/ocamldot.cmx : tools/ocp-build/ocamldot.cmi
-tools/ocp-build/buildValue.cmo : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/buildValue.cmi
-tools/ocp-build/buildValue.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    tools/ocp-build/buildValue.cmi
-tools/ocp-build/versioning.cmo : tools/ocp-build/versioning.cmi
-tools/ocp-build/versioning.cmx : tools/ocp-build/versioning.cmi
-tools/ocp-build/buildOCPTypes.cmo : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/linearToposort.cmi libs/ocplib-lang/intMap.cmi \
-    tools/ocp-build/buildValue.cmi tools/ocp-build/buildOCPTypes.cmi
-tools/ocp-build/buildOCPTypes.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/linearToposort.cmx libs/ocplib-lang/intMap.cmx \
-    tools/ocp-build/buildValue.cmx tools/ocp-build/buildOCPTypes.cmi
-tools/ocp-build/buildOCPTree.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildOCPTree.cmi
-tools/ocp-build/buildOCPTree.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildOCPTree.cmi
-tools/ocp-build/buildOCPParser.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/buildValue.cmi tools/ocp-build/buildOCPTypes.cmi \
-    tools/ocp-build/buildOCPTree.cmi tools/ocp-build/buildOCPParser.cmi
-tools/ocp-build/buildOCPParser.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    tools/ocp-build/buildValue.cmx tools/ocp-build/buildOCPTypes.cmx \
-    tools/ocp-build/buildOCPTree.cmx tools/ocp-build/buildOCPParser.cmi
-tools/ocp-build/buildOCPParse.cmo : libs/ocplib-lang/ocamllexer.cmi \
-    tools/ocp-build/buildOCPParser.cmi tools/ocp-build/buildMisc.cmo \
-    tools/ocp-build/buildOCPParse.cmi
-tools/ocp-build/buildOCPParse.cmx : libs/ocplib-lang/ocamllexer.cmx \
-    tools/ocp-build/buildOCPParser.cmx tools/ocp-build/buildMisc.cmx \
-    tools/ocp-build/buildOCPParse.cmi
-tools/ocp-build/buildOCPPrinter.cmo : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/intMap.cmi tools/ocp-build/buildValue.cmi \
-    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildOCPPrinter.cmi
-tools/ocp-build/buildOCPPrinter.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/intMap.cmx tools/ocp-build/buildValue.cmx \
-    tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildOCPPrinter.cmi
-tools/ocp-build/buildOCPInterp.cmo : tools/ocp-build/versioning.cmi \
-    libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocpString.cmi libs/ocplib-lang/linearToposort.cmi \
-    libs/ocplib-lang/intMap.cmi libs/ocplib-file/fileString.cmi \
-    tools/ocp-build/buildValue.cmi tools/ocp-build/buildSubst.cmi \
-    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildOCPTree.cmi \
-    tools/ocp-build/buildOCPPrinter.cmi tools/ocp-build/buildOCPParse.cmi \
-    tools/ocp-build/buildMisc.cmo tools/ocp-build/buildOCPInterp.cmi
-tools/ocp-build/buildOCPInterp.cmx : tools/ocp-build/versioning.cmx \
-    libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocpString.cmx libs/ocplib-lang/linearToposort.cmx \
-    libs/ocplib-lang/intMap.cmx libs/ocplib-file/fileString.cmx \
-    tools/ocp-build/buildValue.cmx tools/ocp-build/buildSubst.cmx \
-    tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildOCPTree.cmx \
-    tools/ocp-build/buildOCPPrinter.cmx tools/ocp-build/buildOCPParse.cmx \
-    tools/ocp-build/buildMisc.cmx tools/ocp-build/buildOCPInterp.cmi
-tools/ocp-build/buildOCP.cmo : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
-    libs/ocplib-lang/linearToposort.cmi libs/ocplib-lang/intMap.cmi \
-    libs/ocplib-file/fileString.cmi libs/ocplib-file/file.cmi \
-    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildValue.cmi \
-    tools/ocp-build/buildScanner.cmi tools/ocp-build/buildOCPTypes.cmi \
-    tools/ocp-build/buildOCPTree.cmi tools/ocp-build/buildOCPInterp.cmi \
-    tools/ocp-build/buildMisc.cmo tools/ocp-build/buildOCP.cmi
-tools/ocp-build/buildOCP.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocpString.cmx libs/ocplib-unix/minUnix.cmx \
-    libs/ocplib-lang/linearToposort.cmx libs/ocplib-lang/intMap.cmx \
-    libs/ocplib-file/fileString.cmx libs/ocplib-file/file.cmx \
-    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildValue.cmx \
-    tools/ocp-build/buildScanner.cmx tools/ocp-build/buildOCPTypes.cmx \
-    tools/ocp-build/buildOCPTree.cmx tools/ocp-build/buildOCPInterp.cmx \
-    tools/ocp-build/buildMisc.cmx tools/ocp-build/buildOCP.cmi
-tools/ocp-build/buildEngineTypes.cmo : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/intMap.cmi libs/ocplib-file/file.cmi \
-    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildMtime.cmi \
-    tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildEngineTypes.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/intMap.cmx libs/ocplib-file/file.cmx \
-    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildMtime.cmx \
-    tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildEngineGlobals.cmo : libs/ocplib-file/file.cmi \
-    tools/ocp-build/buildEngineTypes.cmi \
-    tools/ocp-build/buildEngineGlobals.cmi
-tools/ocp-build/buildEngineGlobals.cmx : libs/ocplib-file/file.cmx \
-    tools/ocp-build/buildEngineTypes.cmx \
-    tools/ocp-build/buildEngineGlobals.cmi
-tools/ocp-build/buildEngineRules.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/intMap.cmi libs/ocplib-file/file.cmi \
-    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildSubst.cmi \
-    tools/ocp-build/buildEngineTypes.cmi \
-    tools/ocp-build/buildEngineGlobals.cmi
-tools/ocp-build/buildEngineRules.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/intMap.cmx libs/ocplib-file/file.cmx \
-    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildSubst.cmx \
-    tools/ocp-build/buildEngineTypes.cmx \
-    tools/ocp-build/buildEngineGlobals.cmx
-tools/ocp-build/buildEngineContext.cmo : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-unix/onlyWin32.cmi libs/ocplib-unix/onlyUnix.cmi \
-    libs/ocplib-lang/ocpString.cmi libs/ocplib-lang/ocpDigest.cmi \
-    libs/ocplib-unix/minUnix.cmi libs/ocplib-lang/intMap.cmi \
-    libs/ocplib-file/file.cmi tools/ocp-build/buildMtime.cmi \
-    tools/ocp-build/buildEngineTypes.cmi \
-    tools/ocp-build/buildEngineGlobals.cmi \
-    tools/ocp-build/buildEngineContext.cmi
-tools/ocp-build/buildEngineContext.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-unix/onlyWin32.cmx libs/ocplib-unix/onlyUnix.cmx \
-    libs/ocplib-lang/ocpString.cmx libs/ocplib-lang/ocpDigest.cmx \
-    libs/ocplib-unix/minUnix.cmx libs/ocplib-lang/intMap.cmx \
-    libs/ocplib-file/file.cmx tools/ocp-build/buildMtime.cmx \
-    tools/ocp-build/buildEngineTypes.cmx \
-    tools/ocp-build/buildEngineGlobals.cmx \
-    tools/ocp-build/buildEngineContext.cmi
-tools/ocp-build/buildEngineDisplay.cmo : libs/ocplib-lang/stringSet.cmi \
-    libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-unix/minUnix.cmi libs/ocplib-lang/intMap.cmi \
-    libs/ocplib-file/fileString.cmi libs/ocplib-file/file.cmi \
-    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildTerm.cmi \
+    libs/ocplib-config/simpleConfig.cmi libs/ocplib-unix/minUnix.cmi \
+    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildVersion.cmo \
+    tools/ocp-build/buildValue.cmi tools/ocp-build/buildUninstall.cmi \
+    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildTerm.cmi \
+    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlInstall.cmi \
+    tools/ocp-build/buildOCamlConfig.cmi tools/ocp-build/buildOCPTypes.cmi \
+    tools/ocp-build/buildOCPInterp.cmi tools/ocp-build/buildOCP.cmi \
+    tools/ocp-build/buildMisc.cmo tools/ocp-build/buildGlobals.cmo \
     tools/ocp-build/buildEngineTypes.cmi tools/ocp-build/buildEngineRules.cmo \
-    tools/ocp-build/buildEngineGlobals.cmi \
-    tools/ocp-build/buildEngineDisplay.cmi
-tools/ocp-build/buildEngineDisplay.cmx : libs/ocplib-lang/stringSet.cmx \
+    tools/ocp-build/buildEngineDisplay.cmi tools/ocp-build/buildEngine.cmi \
+    tools/ocp-build/buildConfig.cmi tools/ocp-build/buildArgs.cmo \
+    tools/ocp-build/buildActions.cmi tools/ocp-build/buildActionInit.cmi \
+    tools/ocp-build/buildActionBuild.cmi
+tools/ocp-build/buildActionBuild.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-config/simpleConfig.cmx libs/ocplib-unix/minUnix.cmx \
+    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildVersion.cmx \
+    tools/ocp-build/buildValue.cmx tools/ocp-build/buildUninstall.cmx \
+    tools/ocp-build/buildTypes.cmx tools/ocp-build/buildTerm.cmx \
+    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildOCamlInstall.cmx \
+    tools/ocp-build/buildOCamlConfig.cmx tools/ocp-build/buildOCPTypes.cmx \
+    tools/ocp-build/buildOCPInterp.cmx tools/ocp-build/buildOCP.cmx \
+    tools/ocp-build/buildMisc.cmx tools/ocp-build/buildGlobals.cmx \
+    tools/ocp-build/buildEngineTypes.cmx tools/ocp-build/buildEngineRules.cmx \
+    tools/ocp-build/buildEngineDisplay.cmx tools/ocp-build/buildEngine.cmx \
+    tools/ocp-build/buildConfig.cmx tools/ocp-build/buildArgs.cmx \
+    tools/ocp-build/buildActions.cmx tools/ocp-build/buildActionInit.cmx \
+    tools/ocp-build/buildActionBuild.cmi
+tools/ocp-build/buildActionBuild.cmi : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildOptions.cmi \
+    tools/ocp-build/buildArgs.cmo tools/ocp-build/buildActions.cmi
+tools/ocp-build/buildActionClean.cmo : libs/ocplib-file/file.cmi \
+    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildArgs.cmo \
+    tools/ocp-build/buildActions.cmi
+tools/ocp-build/buildActionClean.cmx : libs/ocplib-file/file.cmx \
+    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildArgs.cmx \
+    tools/ocp-build/buildActions.cmx
+tools/ocp-build/buildActionConfigure.cmo : libs/ocplib-file/file.cmi \
+    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildArgs.cmo
+tools/ocp-build/buildActionConfigure.cmx : libs/ocplib-file/file.cmx \
+    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildArgs.cmx
+tools/ocp-build/buildActionHelp.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/buildOCPInterp.cmi tools/ocp-build/buildMisc.cmo \
+    tools/ocp-build/buildArgs.cmo
+tools/ocp-build/buildActionHelp.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    tools/ocp-build/buildOCPInterp.cmx tools/ocp-build/buildMisc.cmx \
+    tools/ocp-build/buildArgs.cmx
+tools/ocp-build/buildActionInit.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-config/simpleConfig.cmi libs/ocplib-unix/minUnix.cmi \
+    libs/ocplib-file/file.cmi libs/ocplib-debug/debugVerbosity.cmi \
+    tools/ocp-build/buildWarnings.cmi tools/ocp-build/buildVersion.cmo \
+    tools/ocp-build/buildValue.cmi tools/ocp-build/buildTypes.cmi \
+    tools/ocp-build/buildTerm.cmi tools/ocp-build/buildSubst.cmi \
+    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOasis.cmi \
+    tools/ocp-build/buildOCamlVariables.cmo \
+    tools/ocp-build/buildOCamlRules.cmi tools/ocp-build/buildOCamlMeta.cmi \
+    tools/ocp-build/buildOCamlConfig.cmi tools/ocp-build/buildOCPTypes.cmi \
+    tools/ocp-build/buildOCPTree.cmi tools/ocp-build/buildOCPPrinter.cmi \
+    tools/ocp-build/buildOCPInterp.cmi tools/ocp-build/buildOCP.cmi \
+    tools/ocp-build/buildMtime.cmi tools/ocp-build/buildMisc.cmo \
+    tools/ocp-build/buildGlobals.cmo tools/ocp-build/buildEngineTypes.cmi \
+    tools/ocp-build/buildEngineDisplay.cmi \
+    tools/ocp-build/buildEngineContext.cmi tools/ocp-build/buildArgs.cmo \
+    tools/ocp-build/buildActionsWarnings.cmi tools/ocp-build/buildActions.cmi \
+    tools/ocp-build/buildActionInit.cmi
+tools/ocp-build/buildActionInit.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-config/simpleConfig.cmx libs/ocplib-unix/minUnix.cmx \
+    libs/ocplib-file/file.cmx libs/ocplib-debug/debugVerbosity.cmx \
+    tools/ocp-build/buildWarnings.cmx tools/ocp-build/buildVersion.cmx \
+    tools/ocp-build/buildValue.cmx tools/ocp-build/buildTypes.cmx \
+    tools/ocp-build/buildTerm.cmx tools/ocp-build/buildSubst.cmx \
+    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildOasis.cmx \
+    tools/ocp-build/buildOCamlVariables.cmx \
+    tools/ocp-build/buildOCamlRules.cmx tools/ocp-build/buildOCamlMeta.cmx \
+    tools/ocp-build/buildOCamlConfig.cmx tools/ocp-build/buildOCPTypes.cmx \
+    tools/ocp-build/buildOCPTree.cmx tools/ocp-build/buildOCPPrinter.cmx \
+    tools/ocp-build/buildOCPInterp.cmx tools/ocp-build/buildOCP.cmx \
+    tools/ocp-build/buildMtime.cmx tools/ocp-build/buildMisc.cmx \
+    tools/ocp-build/buildGlobals.cmx tools/ocp-build/buildEngineTypes.cmx \
+    tools/ocp-build/buildEngineDisplay.cmx \
+    tools/ocp-build/buildEngineContext.cmx tools/ocp-build/buildArgs.cmx \
+    tools/ocp-build/buildActionsWarnings.cmx tools/ocp-build/buildActions.cmx \
+    tools/ocp-build/buildActionInit.cmi
+tools/ocp-build/buildActionInit.cmi : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildOCPTypes.cmi \
+    tools/ocp-build/buildOCPInterp.cmi tools/ocp-build/buildArgs.cmo \
+    tools/ocp-build/buildActionsWarnings.cmi tools/ocp-build/buildActions.cmi
+tools/ocp-build/buildActionInstall.cmo : libs/ocplib-lang/stringSet.cmi \
+    libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/buildValue.cmi tools/ocp-build/buildUninstall.cmi \
+    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildTerm.cmi \
+    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlInstall.cmi \
+    tools/ocp-build/buildMisc.cmo tools/ocp-build/buildArgs.cmo \
+    tools/ocp-build/buildActions.cmi tools/ocp-build/buildActionBuild.cmi \
+    tools/ocp-build/buildActionInstall.cmi
+tools/ocp-build/buildActionInstall.cmx : libs/ocplib-lang/stringSet.cmx \
     libs/ocplib-lang/stringMap.cmx \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-unix/minUnix.cmx libs/ocplib-lang/intMap.cmx \
-    libs/ocplib-file/fileString.cmx libs/ocplib-file/file.cmx \
+    tools/ocp-build/buildValue.cmx tools/ocp-build/buildUninstall.cmx \
+    tools/ocp-build/buildTypes.cmx tools/ocp-build/buildTerm.cmx \
+    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildOCamlInstall.cmx \
+    tools/ocp-build/buildMisc.cmx tools/ocp-build/buildArgs.cmx \
+    tools/ocp-build/buildActions.cmx tools/ocp-build/buildActionBuild.cmx \
+    tools/ocp-build/buildActionInstall.cmi
+tools/ocp-build/buildActionInstall.cmi : tools/ocp-build/buildArgs.cmo
+tools/ocp-build/buildActionPrefs.cmo : libs/ocplib-file/file.cmi \
+    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildArgs.cmo
+tools/ocp-build/buildActionPrefs.cmx : libs/ocplib-file/file.cmx \
+    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildArgs.cmx
+tools/ocp-build/buildActionQuery.cmo : tools/ocp-build/buildTypes.cmi \
+    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCPTypes.cmi \
+    tools/ocp-build/buildMisc.cmo tools/ocp-build/buildArgs.cmo \
+    tools/ocp-build/buildActionsWarnings.cmi tools/ocp-build/buildActions.cmi \
+    tools/ocp-build/buildActionInit.cmi tools/ocp-build/buildActionBuild.cmi
+tools/ocp-build/buildActionQuery.cmx : tools/ocp-build/buildTypes.cmx \
+    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildOCPTypes.cmx \
+    tools/ocp-build/buildMisc.cmx tools/ocp-build/buildArgs.cmx \
+    tools/ocp-build/buildActionsWarnings.cmx tools/ocp-build/buildActions.cmx \
+    tools/ocp-build/buildActionInit.cmx tools/ocp-build/buildActionBuild.cmx
+tools/ocp-build/buildActionTests.cmo : tools/ocp-build/buildTypes.cmi \
+    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlTest.cmi \
+    tools/ocp-build/buildArgs.cmo tools/ocp-build/buildActions.cmi \
+    tools/ocp-build/buildActionBuild.cmi tools/ocp-build/buildActionTests.cmi
+tools/ocp-build/buildActionTests.cmx : tools/ocp-build/buildTypes.cmx \
+    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildOCamlTest.cmx \
+    tools/ocp-build/buildArgs.cmx tools/ocp-build/buildActions.cmx \
+    tools/ocp-build/buildActionBuild.cmx tools/ocp-build/buildActionTests.cmi
+tools/ocp-build/buildActionTests.cmi : tools/ocp-build/buildArgs.cmo
+tools/ocp-build/buildActionUninstall.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/buildUninstall.cmi tools/ocp-build/buildGlobals.cmo \
+    tools/ocp-build/buildArgs.cmo
+tools/ocp-build/buildActionUninstall.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    tools/ocp-build/buildUninstall.cmx tools/ocp-build/buildGlobals.cmx \
+    tools/ocp-build/buildArgs.cmx
+tools/ocp-build/buildActions.cmo : libs/ocplib-unix/onlyUnix.cmi \
+    libs/ocplib-unix/minUnix.cmi libs/ocplib-file/file.cmi \
+    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildTerm.cmi \
+    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlConfig.cmi \
+    tools/ocp-build/buildGlobals.cmo tools/ocp-build/buildActions.cmi
+tools/ocp-build/buildActions.cmx : libs/ocplib-unix/onlyUnix.cmx \
+    libs/ocplib-unix/minUnix.cmx libs/ocplib-file/file.cmx \
     libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildTerm.cmx \
-    tools/ocp-build/buildEngineTypes.cmx tools/ocp-build/buildEngineRules.cmx \
-    tools/ocp-build/buildEngineGlobals.cmx \
-    tools/ocp-build/buildEngineDisplay.cmi
+    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildOCamlConfig.cmx \
+    tools/ocp-build/buildGlobals.cmx tools/ocp-build/buildActions.cmi
+tools/ocp-build/buildActions.cmi : libs/ocplib-file/file.cmi \
+    tools/ocp-build/buildWarnings.cmi tools/ocp-build/buildOptions.cmi \
+    tools/ocp-build/buildOCamlConfig.cmi
+tools/ocp-build/buildActionsWarnings.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/buildWarnings.cmi tools/ocp-build/buildOCPTypes.cmi \
+    tools/ocp-build/buildOCP.cmi tools/ocp-build/buildActionsWarnings.cmi
+tools/ocp-build/buildActionsWarnings.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    tools/ocp-build/buildWarnings.cmx tools/ocp-build/buildOCPTypes.cmx \
+    tools/ocp-build/buildOCP.cmx tools/ocp-build/buildActionsWarnings.cmi
+tools/ocp-build/buildActionsWarnings.cmi : tools/ocp-build/buildWarnings.cmi \
+    tools/ocp-build/buildOCPTypes.cmi
+tools/ocp-build/buildArgs.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
+    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildVersion.cmo \
+    tools/ocp-build/buildGlobals.cmo tools/ocp-build/buildEngineTypes.cmi
+tools/ocp-build/buildArgs.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/ocpString.cmx libs/ocplib-unix/minUnix.cmx \
+    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildVersion.cmx \
+    tools/ocp-build/buildGlobals.cmx tools/ocp-build/buildEngineTypes.cmx
+tools/ocp-build/buildAutogen.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-file/fileString.cmi libs/ocplib-file/file.cmi \
+    libs/ocplib-file/dir.cmi tools/ocp-build/buildOCPTypes.cmi \
+    tools/ocp-build/buildAutogen.cmi
+tools/ocp-build/buildAutogen.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-file/fileString.cmx libs/ocplib-file/file.cmx \
+    libs/ocplib-file/dir.cmx tools/ocp-build/buildOCPTypes.cmx \
+    tools/ocp-build/buildAutogen.cmi
+tools/ocp-build/buildAutogen.cmi : libs/ocplib-file/file.cmi \
+    tools/ocp-build/buildOCPTypes.cmi
+tools/ocp-build/buildConfig.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
+    libs/ocplib-file/fileString.cmi tools/ocp-build/buildConfig.cmi
+tools/ocp-build/buildConfig.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/ocpString.cmx libs/ocplib-unix/minUnix.cmx \
+    libs/ocplib-file/fileString.cmx tools/ocp-build/buildConfig.cmi
+tools/ocp-build/buildConfig.cmi :
 tools/ocp-build/buildEngine.cmo : \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
     libs/ocplib-lang/ocpDigest.cmi libs/ocplib-unix/minUnix.cmi \
@@ -412,36 +483,84 @@ tools/ocp-build/buildEngine.cmx : \
     tools/ocp-build/buildEngineGlobals.cmx \
     tools/ocp-build/buildEngineDisplay.cmx \
     tools/ocp-build/buildEngineContext.cmx tools/ocp-build/buildEngine.cmi
-tools/ocp-build/buildObjectInspector.cmo : \
+tools/ocp-build/buildEngine.cmi : tools/ocp-build/buildEngineTypes.cmi
+tools/ocp-build/buildEngineContext.cmo : libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/buildMisc.cmo tools/ocp-build/buildObjectInspector.cmi
-tools/ocp-build/buildObjectInspector.cmx : \
+    libs/ocplib-unix/onlyWin32.cmi libs/ocplib-unix/onlyUnix.cmi \
+    libs/ocplib-lang/ocpString.cmi libs/ocplib-lang/ocpDigest.cmi \
+    libs/ocplib-unix/minUnix.cmi libs/ocplib-lang/intMap.cmi \
+    libs/ocplib-file/file.cmi tools/ocp-build/buildMtime.cmi \
+    tools/ocp-build/buildEngineTypes.cmi \
+    tools/ocp-build/buildEngineGlobals.cmi \
+    tools/ocp-build/buildEngineContext.cmi
+tools/ocp-build/buildEngineContext.cmx : libs/ocplib-lang/stringMap.cmx \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
-    tools/ocp-build/buildMisc.cmx tools/ocp-build/buildObjectInspector.cmi
-tools/ocp-build/buildVersion.cmo :
-tools/ocp-build/buildVersion.cmx :
-tools/ocp-build/buildTypes.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-unix/onlyWin32.cmx libs/ocplib-unix/onlyUnix.cmx \
+    libs/ocplib-lang/ocpString.cmx libs/ocplib-lang/ocpDigest.cmx \
+    libs/ocplib-unix/minUnix.cmx libs/ocplib-lang/intMap.cmx \
+    libs/ocplib-file/file.cmx tools/ocp-build/buildMtime.cmx \
+    tools/ocp-build/buildEngineTypes.cmx \
+    tools/ocp-build/buildEngineGlobals.cmx \
+    tools/ocp-build/buildEngineContext.cmi
+tools/ocp-build/buildEngineContext.cmi : \
+    tools/ocp-build/buildEngineTypes.cmi
+tools/ocp-build/buildEngineDisplay.cmo : libs/ocplib-lang/stringSet.cmi \
+    libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/linearToposort.cmi libs/ocplib-file/file.cmi \
-    tools/ocp-build/buildValue.cmi tools/ocp-build/buildOCPTypes.cmi \
-    tools/ocp-build/buildEngineTypes.cmi tools/ocp-build/buildTypes.cmi
-tools/ocp-build/buildTypes.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-unix/minUnix.cmi libs/ocplib-lang/intMap.cmi \
+    libs/ocplib-file/fileString.cmi libs/ocplib-file/file.cmi \
+    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildTerm.cmi \
+    tools/ocp-build/buildEngineTypes.cmi tools/ocp-build/buildEngineRules.cmo \
+    tools/ocp-build/buildEngineGlobals.cmi \
+    tools/ocp-build/buildEngineDisplay.cmi
+tools/ocp-build/buildEngineDisplay.cmx : libs/ocplib-lang/stringSet.cmx \
+    libs/ocplib-lang/stringMap.cmx \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/linearToposort.cmx libs/ocplib-file/file.cmx \
-    tools/ocp-build/buildValue.cmx tools/ocp-build/buildOCPTypes.cmx \
-    tools/ocp-build/buildEngineTypes.cmx tools/ocp-build/buildTypes.cmi
-tools/ocp-build/buildOptions.cmo : \
+    libs/ocplib-unix/minUnix.cmx libs/ocplib-lang/intMap.cmx \
+    libs/ocplib-file/fileString.cmx libs/ocplib-file/file.cmx \
+    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildTerm.cmx \
+    tools/ocp-build/buildEngineTypes.cmx tools/ocp-build/buildEngineRules.cmx \
+    tools/ocp-build/buildEngineGlobals.cmx \
+    tools/ocp-build/buildEngineDisplay.cmi
+tools/ocp-build/buildEngineDisplay.cmi : \
+    tools/ocp-build/buildEngineTypes.cmi
+tools/ocp-build/buildEngineGlobals.cmo : libs/ocplib-file/file.cmi \
+    tools/ocp-build/buildEngineTypes.cmi \
+    tools/ocp-build/buildEngineGlobals.cmi
+tools/ocp-build/buildEngineGlobals.cmx : libs/ocplib-file/file.cmx \
+    tools/ocp-build/buildEngineTypes.cmx \
+    tools/ocp-build/buildEngineGlobals.cmi
+tools/ocp-build/buildEngineGlobals.cmi : \
+    tools/ocp-build/buildEngineTypes.cmi
+tools/ocp-build/buildEngineRules.cmo : \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-config/simpleConfig.cmi libs/ocplib-file/file.cmi \
-    libs/ocplib-file/dir.cmi tools/ocp-build/buildVersion.cmo \
-    tools/ocp-build/buildOCP.cmi tools/ocp-build/buildMisc.cmo \
-    tools/ocp-build/buildOptions.cmi
-tools/ocp-build/buildOptions.cmx : \
+    libs/ocplib-lang/intMap.cmi libs/ocplib-file/file.cmi \
+    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildSubst.cmi \
+    tools/ocp-build/buildEngineTypes.cmi \
+    tools/ocp-build/buildEngineGlobals.cmi
+tools/ocp-build/buildEngineRules.cmx : \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-config/simpleConfig.cmx libs/ocplib-file/file.cmx \
-    libs/ocplib-file/dir.cmx tools/ocp-build/buildVersion.cmx \
-    tools/ocp-build/buildOCP.cmx tools/ocp-build/buildMisc.cmx \
-    tools/ocp-build/buildOptions.cmi
+    libs/ocplib-lang/intMap.cmx libs/ocplib-file/file.cmx \
+    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildSubst.cmx \
+    tools/ocp-build/buildEngineTypes.cmx \
+    tools/ocp-build/buildEngineGlobals.cmx
+tools/ocp-build/buildEngineTypes.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/intMap.cmi libs/ocplib-file/file.cmi \
+    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildMtime.cmi \
+    tools/ocp-build/buildEngineTypes.cmi
+tools/ocp-build/buildEngineTypes.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/intMap.cmx libs/ocplib-file/file.cmx \
+    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildMtime.cmx \
+    tools/ocp-build/buildEngineTypes.cmi
+tools/ocp-build/buildEngineTypes.cmi : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/intMap.cmi libs/ocplib-file/file.cmi \
+    tools/ocp-build/buildMtime.cmi
+tools/ocp-build/buildFind.cmo : tools/ocp-build/buildFind.cmi
+tools/ocp-build/buildFind.cmx : tools/ocp-build/buildFind.cmi
+tools/ocp-build/buildFind.cmi :
 tools/ocp-build/buildGlobals.cmo : libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
     libs/ocplib-lang/ocpDigest.cmi libs/ocplib-file/fileString.cmi \
@@ -458,84 +577,151 @@ tools/ocp-build/buildGlobals.cmx : libs/ocplib-lang/stringMap.cmx \
     tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildMisc.cmx \
     tools/ocp-build/buildEngineTypes.cmx tools/ocp-build/buildEngineRules.cmx \
     tools/ocp-build/buildEngineContext.cmx
-tools/ocp-build/buildConfig.cmo : \
+tools/ocp-build/buildMain.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildMisc.cmo \
+    tools/ocp-build/buildGlobals.cmo tools/ocp-build/buildArgs.cmo \
+    tools/ocp-build/buildActions.cmi tools/ocp-build/buildActionUninstall.cmo \
+    tools/ocp-build/buildActionTests.cmi tools/ocp-build/buildActionQuery.cmo \
+    tools/ocp-build/buildActionPrefs.cmo \
+    tools/ocp-build/buildActionInstall.cmi \
+    tools/ocp-build/buildActionInit.cmi tools/ocp-build/buildActionHelp.cmo \
+    tools/ocp-build/buildActionConfigure.cmo \
+    tools/ocp-build/buildActionClean.cmo tools/ocp-build/buildActionBuild.cmi
+tools/ocp-build/buildMain.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildMisc.cmx \
+    tools/ocp-build/buildGlobals.cmx tools/ocp-build/buildArgs.cmx \
+    tools/ocp-build/buildActions.cmx tools/ocp-build/buildActionUninstall.cmx \
+    tools/ocp-build/buildActionTests.cmx tools/ocp-build/buildActionQuery.cmx \
+    tools/ocp-build/buildActionPrefs.cmx \
+    tools/ocp-build/buildActionInstall.cmx \
+    tools/ocp-build/buildActionInit.cmx tools/ocp-build/buildActionHelp.cmx \
+    tools/ocp-build/buildActionConfigure.cmx \
+    tools/ocp-build/buildActionClean.cmx tools/ocp-build/buildActionBuild.cmx
+tools/ocp-build/buildMisc.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-unix/onlyWin32.cmi libs/ocplib-unix/onlyUnix.cmi \
+    libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
+    libs/ocplib-file/fileString.cmi
+tools/ocp-build/buildMisc.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-unix/onlyWin32.cmx libs/ocplib-unix/onlyUnix.cmx \
+    libs/ocplib-lang/ocpString.cmx libs/ocplib-unix/minUnix.cmx \
+    libs/ocplib-file/fileString.cmx
+tools/ocp-build/buildMtime.cmo : libs/ocplib-lang/ocpDigest.cmi \
+    libs/ocplib-unix/minUnix.cmi tools/ocp-build/buildMtime.cmi
+tools/ocp-build/buildMtime.cmx : libs/ocplib-lang/ocpDigest.cmx \
+    libs/ocplib-unix/minUnix.cmx tools/ocp-build/buildMtime.cmi
+tools/ocp-build/buildMtime.cmi :
+tools/ocp-build/buildOCP.cmo : libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
     libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
-    libs/ocplib-file/fileString.cmi tools/ocp-build/buildConfig.cmi
-tools/ocp-build/buildConfig.cmx : \
+    libs/ocplib-lang/linearToposort.cmi libs/ocplib-lang/intMap.cmi \
+    libs/ocplib-file/fileString.cmi libs/ocplib-file/file.cmi \
+    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildWarnings.cmi \
+    tools/ocp-build/buildValue.cmi tools/ocp-build/buildScanner.cmi \
+    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildOCPTree.cmi \
+    tools/ocp-build/buildOCPInterp.cmi tools/ocp-build/buildMisc.cmo \
+    tools/ocp-build/buildOCP.cmi
+tools/ocp-build/buildOCP.cmx : libs/ocplib-lang/stringMap.cmx \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
     libs/ocplib-lang/ocpString.cmx libs/ocplib-unix/minUnix.cmx \
-    libs/ocplib-file/fileString.cmx tools/ocp-build/buildConfig.cmi
-tools/ocp-build/buildUninstall.cmo : libs/ocplib-lang/stringSet.cmi \
+    libs/ocplib-lang/linearToposort.cmx libs/ocplib-lang/intMap.cmx \
+    libs/ocplib-file/fileString.cmx libs/ocplib-file/file.cmx \
+    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildWarnings.cmx \
+    tools/ocp-build/buildValue.cmx tools/ocp-build/buildScanner.cmx \
+    tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildOCPTree.cmx \
+    tools/ocp-build/buildOCPInterp.cmx tools/ocp-build/buildMisc.cmx \
+    tools/ocp-build/buildOCP.cmi
+tools/ocp-build/buildOCP.cmi : libs/ocplib-file/file.cmi \
+    tools/ocp-build/buildWarnings.cmi tools/ocp-build/buildOCPTypes.cmi \
+    tools/ocp-build/buildOCPInterp.cmi
+tools/ocp-build/buildOCPInterp.cmo : tools/ocp-build/versioning.cmi \
     libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
-    libs/ocplib-file/fileLines.cmi tools/ocp-build/buildScanner.cmi \
-    tools/ocp-build/buildUninstall.cmi
-tools/ocp-build/buildUninstall.cmx : libs/ocplib-lang/stringSet.cmx \
+    libs/ocplib-lang/ocpString.cmi libs/ocplib-lang/linearToposort.cmi \
+    libs/ocplib-lang/intMap.cmi libs/ocplib-file/fileString.cmi \
+    tools/ocp-build/buildWarnings.cmi tools/ocp-build/buildValue.cmi \
+    tools/ocp-build/buildSubst.cmi tools/ocp-build/buildOCPTypes.cmi \
+    tools/ocp-build/buildOCPTree.cmi tools/ocp-build/buildOCPPrinter.cmi \
+    tools/ocp-build/buildOCPParse.cmi tools/ocp-build/buildMisc.cmo \
+    tools/ocp-build/buildOCPInterp.cmi
+tools/ocp-build/buildOCPInterp.cmx : tools/ocp-build/versioning.cmx \
     libs/ocplib-lang/stringMap.cmx \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocpString.cmx libs/ocplib-unix/minUnix.cmx \
-    libs/ocplib-file/fileLines.cmx tools/ocp-build/buildScanner.cmx \
-    tools/ocp-build/buildUninstall.cmi
-tools/ocp-build/buildAutogen.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-lang/ocpString.cmx libs/ocplib-lang/linearToposort.cmx \
+    libs/ocplib-lang/intMap.cmx libs/ocplib-file/fileString.cmx \
+    tools/ocp-build/buildWarnings.cmx tools/ocp-build/buildValue.cmx \
+    tools/ocp-build/buildSubst.cmx tools/ocp-build/buildOCPTypes.cmx \
+    tools/ocp-build/buildOCPTree.cmx tools/ocp-build/buildOCPPrinter.cmx \
+    tools/ocp-build/buildOCPParse.cmx tools/ocp-build/buildMisc.cmx \
+    tools/ocp-build/buildOCPInterp.cmi
+tools/ocp-build/buildOCPInterp.cmi : libs/ocplib-lang/stringSubst.cmi \
+    libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-file/fileString.cmi libs/ocplib-file/file.cmi \
-    libs/ocplib-file/dir.cmi tools/ocp-build/buildOCPTypes.cmi \
-    tools/ocp-build/buildAutogen.cmi
-tools/ocp-build/buildAutogen.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-file/fileString.cmx libs/ocplib-file/file.cmx \
-    libs/ocplib-file/dir.cmx tools/ocp-build/buildOCPTypes.cmx \
-    tools/ocp-build/buildAutogen.cmi
-tools/ocp-build/metaTypes.cmo : libs/ocplib-lang/stringMap.cmi \
+    tools/ocp-build/buildWarnings.cmi tools/ocp-build/buildValue.cmi \
+    tools/ocp-build/buildOCPTypes.cmi
+tools/ocp-build/buildOCPParse.cmo : libs/ocplib-lang/ocamllexer.cmi \
+    tools/ocp-build/buildOCPParser.cmi tools/ocp-build/buildMisc.cmo \
+    tools/ocp-build/buildOCPParse.cmi
+tools/ocp-build/buildOCPParse.cmx : libs/ocplib-lang/ocamllexer.cmx \
+    tools/ocp-build/buildOCPParser.cmx tools/ocp-build/buildMisc.cmx \
+    tools/ocp-build/buildOCPParse.cmi
+tools/ocp-build/buildOCPParse.cmi : tools/ocp-build/buildOCPTree.cmi
+tools/ocp-build/buildOCPParser.cmo : \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/metaTypes.cmi
-tools/ocp-build/metaTypes.cmx : libs/ocplib-lang/stringMap.cmx \
+    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildOCPTree.cmi \
+    tools/ocp-build/buildOCPParser.cmi
+tools/ocp-build/buildOCPParser.cmx : \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
-    tools/ocp-build/metaTypes.cmi
-tools/ocp-build/metaLexer.cmo : tools/ocp-build/metaLexer.cmi
-tools/ocp-build/metaLexer.cmx : tools/ocp-build/metaLexer.cmi
-tools/ocp-build/metaFile.cmo : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/metaTypes.cmi tools/ocp-build/metaFile.cmi
-tools/ocp-build/metaFile.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    tools/ocp-build/metaTypes.cmx tools/ocp-build/metaFile.cmi
-tools/ocp-build/metaParser.cmo : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocpString.cmi tools/ocp-build/metaTypes.cmi \
-    tools/ocp-build/metaLexer.cmi tools/ocp-build/metaFile.cmi \
-    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/metaParser.cmi
-tools/ocp-build/metaParser.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocpString.cmx tools/ocp-build/metaTypes.cmx \
-    tools/ocp-build/metaLexer.cmx tools/ocp-build/metaFile.cmx \
-    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/metaParser.cmi
-tools/ocp-build/metaConfig.cmo : libs/ocplib-lang/ocpString.cmi \
-    tools/ocp-build/buildMisc.cmo tools/ocp-build/metaConfig.cmi
-tools/ocp-build/metaConfig.cmx : libs/ocplib-lang/ocpString.cmx \
-    tools/ocp-build/buildMisc.cmx tools/ocp-build/metaConfig.cmi
-tools/ocp-build/buildOCamlConfig.cmo : libs/ocplib-lang/ocpString.cmi \
-    libs/ocplib-unix/minUnix.cmi tools/ocp-build/metaConfig.cmi \
-    tools/ocp-build/buildValue.cmi tools/ocp-build/buildSubst.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildMisc.cmo \
-    tools/ocp-build/buildConfig.cmi tools/ocp-build/buildOCamlConfig.cmi
-tools/ocp-build/buildOCamlConfig.cmx : libs/ocplib-lang/ocpString.cmx \
-    libs/ocplib-unix/minUnix.cmx tools/ocp-build/metaConfig.cmx \
-    tools/ocp-build/buildValue.cmx tools/ocp-build/buildSubst.cmx \
-    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildMisc.cmx \
-    tools/ocp-build/buildConfig.cmx tools/ocp-build/buildOCamlConfig.cmi
-tools/ocp-build/buildOCamlTypes.cmo : libs/ocplib-lang/stringMap.cmi \
+    tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildOCPTree.cmx \
+    tools/ocp-build/buildOCPParser.cmi
+tools/ocp-build/buildOCPParser.cmi : tools/ocp-build/buildOCPTree.cmi
+tools/ocp-build/buildOCPPrinter.cmo : libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
     libs/ocplib-lang/intMap.cmi tools/ocp-build/buildValue.cmi \
-    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildEngineTypes.cmi \
-    tools/ocp-build/buildOCamlTypes.cmi
-tools/ocp-build/buildOCamlTypes.cmx : libs/ocplib-lang/stringMap.cmx \
+    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildOCPPrinter.cmi
+tools/ocp-build/buildOCPPrinter.cmx : libs/ocplib-lang/stringMap.cmx \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
     libs/ocplib-lang/intMap.cmx tools/ocp-build/buildValue.cmx \
-    tools/ocp-build/buildTypes.cmx tools/ocp-build/buildEngineTypes.cmx \
-    tools/ocp-build/buildOCamlTypes.cmi
+    tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildOCPPrinter.cmi
+tools/ocp-build/buildOCPPrinter.cmi : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/buildValue.cmi tools/ocp-build/buildOCPTypes.cmi
+tools/ocp-build/buildOCPTree.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildOCPTree.cmi
+tools/ocp-build/buildOCPTree.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildOCPTree.cmi
+tools/ocp-build/buildOCPTree.cmi : tools/ocp-build/buildOCPTypes.cmi
+tools/ocp-build/buildOCPTypes.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/linearToposort.cmi libs/ocplib-lang/intMap.cmi \
+    tools/ocp-build/buildValue.cmi tools/ocp-build/buildOCPTypes.cmi
+tools/ocp-build/buildOCPTypes.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/linearToposort.cmx libs/ocplib-lang/intMap.cmx \
+    tools/ocp-build/buildValue.cmx tools/ocp-build/buildOCPTypes.cmi
+tools/ocp-build/buildOCPTypes.cmi : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/linearToposort.cmi libs/ocplib-lang/intMap.cmi \
+    tools/ocp-build/buildValue.cmi
+tools/ocp-build/buildOCamlConfig.cmo : libs/ocplib-lang/ocpString.cmi \
+    libs/ocplib-unix/minUnix.cmi tools/ocp-build/metaConfig.cmi \
+    tools/ocp-build/buildWarnings.cmi tools/ocp-build/buildValue.cmi \
+    tools/ocp-build/buildSubst.cmi tools/ocp-build/buildOptions.cmi \
+    tools/ocp-build/buildMisc.cmo tools/ocp-build/buildConfig.cmi \
+    tools/ocp-build/buildOCamlConfig.cmi
+tools/ocp-build/buildOCamlConfig.cmx : libs/ocplib-lang/ocpString.cmx \
+    libs/ocplib-unix/minUnix.cmx tools/ocp-build/metaConfig.cmx \
+    tools/ocp-build/buildWarnings.cmx tools/ocp-build/buildValue.cmx \
+    tools/ocp-build/buildSubst.cmx tools/ocp-build/buildOptions.cmx \
+    tools/ocp-build/buildMisc.cmx tools/ocp-build/buildConfig.cmx \
+    tools/ocp-build/buildOCamlConfig.cmi
+tools/ocp-build/buildOCamlConfig.cmi : tools/ocp-build/buildWarnings.cmi \
+    tools/ocp-build/buildValue.cmi tools/ocp-build/buildOptions.cmi
 tools/ocp-build/buildOCamlGlobals.cmo : libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
     libs/ocplib-lang/intMap.cmi tools/ocp-build/buildValue.cmi \
@@ -546,50 +732,6 @@ tools/ocp-build/buildOCamlGlobals.cmx : libs/ocplib-lang/stringMap.cmx \
     libs/ocplib-lang/intMap.cmx tools/ocp-build/buildValue.cmx \
     tools/ocp-build/buildTypes.cmx tools/ocp-build/buildOptions.cmx \
     tools/ocp-build/buildOCamlTypes.cmx tools/ocp-build/buildGlobals.cmx
-tools/ocp-build/buildOCamlMisc.cmo : libs/ocplib-unix/minUnix.cmi \
-    tools/ocp-build/buildEngineTypes.cmi \
-    tools/ocp-build/buildEngineContext.cmi
-tools/ocp-build/buildOCamlMisc.cmx : libs/ocplib-unix/minUnix.cmx \
-    tools/ocp-build/buildEngineTypes.cmx \
-    tools/ocp-build/buildEngineContext.cmx
-tools/ocp-build/buildOCamlVariables.cmo : tools/ocp-build/buildValue.cmi
-tools/ocp-build/buildOCamlVariables.cmx : tools/ocp-build/buildValue.cmx
-tools/ocp-build/buildOCamldep.cmo : libs/ocplib-lang/stringSet.cmi \
-    libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocpString.cmi tools/ocp-build/buildValue.cmi \
-    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildOCamlVariables.cmo \
-    tools/ocp-build/buildOCamlTypes.cmi tools/ocp-build/buildOCamlGlobals.cmo \
-    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildGlobals.cmo \
-    tools/ocp-build/buildEngineTypes.cmi tools/ocp-build/buildOCamldep.cmi
-tools/ocp-build/buildOCamldep.cmx : libs/ocplib-lang/stringSet.cmx \
-    libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocpString.cmx tools/ocp-build/buildValue.cmx \
-    tools/ocp-build/buildTypes.cmx tools/ocp-build/buildOCamlVariables.cmx \
-    tools/ocp-build/buildOCamlTypes.cmx tools/ocp-build/buildOCamlGlobals.cmx \
-    tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildGlobals.cmx \
-    tools/ocp-build/buildEngineTypes.cmx tools/ocp-build/buildOCamldep.cmi
-tools/ocp-build/buildOCamlSyntaxes.cmo : libs/ocplib-lang/stringSet.cmi \
-    libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocpString.cmi tools/ocp-build/buildValue.cmi \
-    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildOCamlVariables.cmo \
-    tools/ocp-build/buildOCamlTypes.cmi tools/ocp-build/buildOCamlMisc.cmo \
-    tools/ocp-build/buildOCamlGlobals.cmo tools/ocp-build/buildOCPTree.cmi \
-    tools/ocp-build/buildMisc.cmo tools/ocp-build/buildGlobals.cmo \
-    tools/ocp-build/buildEngineTypes.cmi tools/ocp-build/buildEngineRules.cmo \
-    tools/ocp-build/buildOCamlSyntaxes.cmi
-tools/ocp-build/buildOCamlSyntaxes.cmx : libs/ocplib-lang/stringSet.cmx \
-    libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocpString.cmx tools/ocp-build/buildValue.cmx \
-    tools/ocp-build/buildTypes.cmx tools/ocp-build/buildOCamlVariables.cmx \
-    tools/ocp-build/buildOCamlTypes.cmx tools/ocp-build/buildOCamlMisc.cmx \
-    tools/ocp-build/buildOCamlGlobals.cmx tools/ocp-build/buildOCPTree.cmx \
-    tools/ocp-build/buildMisc.cmx tools/ocp-build/buildGlobals.cmx \
-    tools/ocp-build/buildEngineTypes.cmx tools/ocp-build/buildEngineRules.cmx \
-    tools/ocp-build/buildOCamlSyntaxes.cmi
 tools/ocp-build/buildOCamlInstall.cmo : \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
     libs/ocplib-unix/minUnix.cmi tools/ocp-build/metaTypes.cmi \
@@ -614,6 +756,29 @@ tools/ocp-build/buildOCamlInstall.cmx : \
     tools/ocp-build/buildEngineTypes.cmx \
     tools/ocp-build/buildEngineGlobals.cmx \
     tools/ocp-build/buildOCamlInstall.cmi
+tools/ocp-build/buildOCamlInstall.cmi : tools/ocp-build/buildTypes.cmi \
+    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlConfig.cmi
+tools/ocp-build/buildOCamlMeta.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/ocpString.cmi tools/ocp-build/metaTypes.cmi \
+    tools/ocp-build/metaParser.cmi tools/ocp-build/buildValue.cmi \
+    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildOCPPrinter.cmi \
+    tools/ocp-build/buildOCPInterp.cmi tools/ocp-build/buildEngineTypes.cmi \
+    tools/ocp-build/buildOCamlMeta.cmi
+tools/ocp-build/buildOCamlMeta.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/ocpString.cmx tools/ocp-build/metaTypes.cmx \
+    tools/ocp-build/metaParser.cmx tools/ocp-build/buildValue.cmx \
+    tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildOCPPrinter.cmx \
+    tools/ocp-build/buildOCPInterp.cmx tools/ocp-build/buildEngineTypes.cmx \
+    tools/ocp-build/buildOCamlMeta.cmi
+tools/ocp-build/buildOCamlMeta.cmi : tools/ocp-build/buildOCPInterp.cmi
+tools/ocp-build/buildOCamlMisc.cmo : libs/ocplib-unix/minUnix.cmi \
+    tools/ocp-build/buildEngineTypes.cmi \
+    tools/ocp-build/buildEngineContext.cmi
+tools/ocp-build/buildOCamlMisc.cmx : libs/ocplib-unix/minUnix.cmx \
+    tools/ocp-build/buildEngineTypes.cmx \
+    tools/ocp-build/buildEngineContext.cmx
 tools/ocp-build/buildOCamlRules.cmo : libs/ocplib-lang/stringSubst.cmi \
     libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
@@ -654,20 +819,33 @@ tools/ocp-build/buildOCamlRules.cmx : libs/ocplib-lang/stringSubst.cmx \
     tools/ocp-build/buildEngineGlobals.cmx \
     tools/ocp-build/buildEngineContext.cmx \
     tools/ocp-build/buildOCamlRules.cmi
-tools/ocp-build/buildOCamlMeta.cmo : libs/ocplib-lang/stringMap.cmi \
+tools/ocp-build/buildOCamlRules.cmi : tools/ocp-build/buildTypes.cmi \
+    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlConfig.cmi \
+    tools/ocp-build/buildOCPTypes.cmi
+tools/ocp-build/buildOCamlSyntaxes.cmo : libs/ocplib-lang/stringSet.cmi \
+    libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocpString.cmi tools/ocp-build/metaTypes.cmi \
-    tools/ocp-build/metaParser.cmi tools/ocp-build/buildValue.cmi \
-    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildOCPPrinter.cmi \
-    tools/ocp-build/buildOCPInterp.cmi tools/ocp-build/buildEngineTypes.cmi \
-    tools/ocp-build/buildOCamlMeta.cmi
-tools/ocp-build/buildOCamlMeta.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-lang/ocpString.cmi libs/ocplib-debug/debugVerbosity.cmi \
+    tools/ocp-build/buildValue.cmi tools/ocp-build/buildTypes.cmi \
+    tools/ocp-build/buildOCamlVariables.cmo \
+    tools/ocp-build/buildOCamlTypes.cmi tools/ocp-build/buildOCamlMisc.cmo \
+    tools/ocp-build/buildOCamlGlobals.cmo tools/ocp-build/buildOCPTree.cmi \
+    tools/ocp-build/buildMisc.cmo tools/ocp-build/buildEngineTypes.cmi \
+    tools/ocp-build/buildEngineRules.cmo \
+    tools/ocp-build/buildOCamlSyntaxes.cmi
+tools/ocp-build/buildOCamlSyntaxes.cmx : libs/ocplib-lang/stringSet.cmx \
+    libs/ocplib-lang/stringMap.cmx \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocpString.cmx tools/ocp-build/metaTypes.cmx \
-    tools/ocp-build/metaParser.cmx tools/ocp-build/buildValue.cmx \
-    tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildOCPPrinter.cmx \
-    tools/ocp-build/buildOCPInterp.cmx tools/ocp-build/buildEngineTypes.cmx \
-    tools/ocp-build/buildOCamlMeta.cmi
+    libs/ocplib-lang/ocpString.cmx libs/ocplib-debug/debugVerbosity.cmx \
+    tools/ocp-build/buildValue.cmx tools/ocp-build/buildTypes.cmx \
+    tools/ocp-build/buildOCamlVariables.cmx \
+    tools/ocp-build/buildOCamlTypes.cmx tools/ocp-build/buildOCamlMisc.cmx \
+    tools/ocp-build/buildOCamlGlobals.cmx tools/ocp-build/buildOCPTree.cmx \
+    tools/ocp-build/buildMisc.cmx tools/ocp-build/buildEngineTypes.cmx \
+    tools/ocp-build/buildEngineRules.cmx \
+    tools/ocp-build/buildOCamlSyntaxes.cmi
+tools/ocp-build/buildOCamlSyntaxes.cmi : tools/ocp-build/buildValue.cmi \
+    tools/ocp-build/buildOCamlTypes.cmi tools/ocp-build/buildEngineTypes.cmi
 tools/ocp-build/buildOCamlTest.cmo : libs/ocplib-lang/stringSubst.cmi \
     libs/ocplib-unix/onlyUnix.cmi libs/ocplib-unix/minUnix.cmi \
     libs/ocplib-lang/intMap.cmi libs/ocplib-file/fileString.cmi \
@@ -686,6 +864,44 @@ tools/ocp-build/buildOCamlTest.cmx : libs/ocplib-lang/stringSubst.cmx \
     tools/ocp-build/buildOCamlGlobals.cmx tools/ocp-build/buildOCPTypes.cmx \
     tools/ocp-build/buildMisc.cmx tools/ocp-build/buildEngineTypes.cmx \
     tools/ocp-build/buildConfig.cmx tools/ocp-build/buildOCamlTest.cmi
+tools/ocp-build/buildOCamlTest.cmi : tools/ocp-build/buildTypes.cmi \
+    tools/ocp-build/buildEngineTypes.cmi
+tools/ocp-build/buildOCamlTypes.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/intMap.cmi tools/ocp-build/buildValue.cmi \
+    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildEngineTypes.cmi \
+    tools/ocp-build/buildOCamlTypes.cmi
+tools/ocp-build/buildOCamlTypes.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/intMap.cmx tools/ocp-build/buildValue.cmx \
+    tools/ocp-build/buildTypes.cmx tools/ocp-build/buildEngineTypes.cmx \
+    tools/ocp-build/buildOCamlTypes.cmi
+tools/ocp-build/buildOCamlTypes.cmi : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/intMap.cmi tools/ocp-build/buildValue.cmi \
+    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildEngineTypes.cmi
+tools/ocp-build/buildOCamlVariables.cmo : tools/ocp-build/buildValue.cmi
+tools/ocp-build/buildOCamlVariables.cmx : tools/ocp-build/buildValue.cmx
+tools/ocp-build/buildOCamldep.cmo : libs/ocplib-lang/stringSet.cmi \
+    libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/ocpString.cmi libs/ocplib-debug/debugVerbosity.cmi \
+    tools/ocp-build/buildValue.cmi tools/ocp-build/buildTypes.cmi \
+    tools/ocp-build/buildOCamlVariables.cmo \
+    tools/ocp-build/buildOCamlTypes.cmi tools/ocp-build/buildOCamlGlobals.cmo \
+    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildEngineTypes.cmi \
+    tools/ocp-build/buildOCamldep.cmi
+tools/ocp-build/buildOCamldep.cmx : libs/ocplib-lang/stringSet.cmx \
+    libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/ocpString.cmx libs/ocplib-debug/debugVerbosity.cmx \
+    tools/ocp-build/buildValue.cmx tools/ocp-build/buildTypes.cmx \
+    tools/ocp-build/buildOCamlVariables.cmx \
+    tools/ocp-build/buildOCamlTypes.cmx tools/ocp-build/buildOCamlGlobals.cmx \
+    tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/buildEngineTypes.cmx \
+    tools/ocp-build/buildOCamldep.cmi
+tools/ocp-build/buildOCamldep.cmi : tools/ocp-build/buildValue.cmi \
+    tools/ocp-build/buildOCamlTypes.cmi tools/ocp-build/buildEngineTypes.cmi
 tools/ocp-build/buildOasis.cmo : \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
     libs/ocplib-lang/ocpString.cmi libs/ocplib-lang/ocpGenlex.cmi \
@@ -696,298 +912,132 @@ tools/ocp-build/buildOasis.cmx : \
     libs/ocplib-lang/ocpString.cmx libs/ocplib-lang/ocpGenlex.cmx \
     tools/ocp-build/buildValue.cmx tools/ocp-build/buildOCPTypes.cmx \
     tools/ocp-build/buildOCPInterp.cmx tools/ocp-build/buildOasis.cmi
-tools/ocp-build/buildArgs.cmo : \
+tools/ocp-build/buildOasis.cmi : tools/ocp-build/buildOCPInterp.cmi
+tools/ocp-build/buildObjectInspector.cmo : \
+    tools/ocp-build/buildObjectInspector.cmi
+tools/ocp-build/buildObjectInspector.cmx : \
+    tools/ocp-build/buildObjectInspector.cmi
+tools/ocp-build/buildObjectInspector.cmi :
+tools/ocp-build/buildOptions.cmo : libs/ocplib-lang/stringSet.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
-    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildVersion.cmo \
-    tools/ocp-build/buildGlobals.cmo tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildArgs.cmx : \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-lang/ocpString.cmx libs/ocplib-unix/minUnix.cmx \
-    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildVersion.cmx \
-    tools/ocp-build/buildGlobals.cmx tools/ocp-build/buildEngineTypes.cmx
-tools/ocp-build/buildActions.cmo : libs/ocplib-unix/onlyUnix.cmi \
-    libs/ocplib-unix/minUnix.cmi libs/ocplib-file/file.cmi \
-    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildTerm.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlConfig.cmi \
-    tools/ocp-build/buildGlobals.cmo tools/ocp-build/buildActions.cmi
-tools/ocp-build/buildActions.cmx : libs/ocplib-unix/onlyUnix.cmx \
-    libs/ocplib-unix/minUnix.cmx libs/ocplib-file/file.cmx \
-    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildTerm.cmx \
-    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildOCamlConfig.cmx \
-    tools/ocp-build/buildGlobals.cmx tools/ocp-build/buildActions.cmi
-tools/ocp-build/buildActionInit.cmo : tools/ocp-build/buildOptions.cmi \
-    tools/ocp-build/buildMisc.cmo tools/ocp-build/buildArgs.cmo
-tools/ocp-build/buildActionInit.cmx : tools/ocp-build/buildOptions.cmx \
-    tools/ocp-build/buildMisc.cmx tools/ocp-build/buildArgs.cmx
-tools/ocp-build/buildActionPrefs.cmo : libs/ocplib-file/file.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildArgs.cmo
-tools/ocp-build/buildActionPrefs.cmx : libs/ocplib-file/file.cmx \
-    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildArgs.cmx
-tools/ocp-build/buildActionConfigure.cmo : libs/ocplib-file/file.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildArgs.cmo
-tools/ocp-build/buildActionConfigure.cmx : libs/ocplib-file/file.cmx \
-    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildArgs.cmx
-tools/ocp-build/buildActionBuild.cmo : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-config/simpleConfig.cmi libs/ocplib-unix/minUnix.cmi \
-    libs/ocplib-file/file.cmi libs/ocplib-debug/debugVerbosity.cmi \
-    tools/ocp-build/buildVersion.cmo tools/ocp-build/buildValue.cmi \
-    tools/ocp-build/buildUninstall.cmi tools/ocp-build/buildTypes.cmi \
-    tools/ocp-build/buildTerm.cmi tools/ocp-build/buildSubst.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOasis.cmi \
-    tools/ocp-build/buildOCamlVariables.cmo \
-    tools/ocp-build/buildOCamlRules.cmi tools/ocp-build/buildOCamlMeta.cmi \
-    tools/ocp-build/buildOCamlInstall.cmi \
-    tools/ocp-build/buildOCamlConfig.cmi tools/ocp-build/buildOCPTypes.cmi \
-    tools/ocp-build/buildOCPTree.cmi tools/ocp-build/buildOCPPrinter.cmi \
-    tools/ocp-build/buildOCPInterp.cmi tools/ocp-build/buildOCP.cmi \
-    tools/ocp-build/buildMtime.cmi tools/ocp-build/buildMisc.cmo \
-    tools/ocp-build/buildGlobals.cmo tools/ocp-build/buildEngineTypes.cmi \
-    tools/ocp-build/buildEngineRules.cmo \
-    tools/ocp-build/buildEngineDisplay.cmi \
-    tools/ocp-build/buildEngineContext.cmi tools/ocp-build/buildEngine.cmi \
-    tools/ocp-build/buildConfig.cmi tools/ocp-build/buildArgs.cmo \
-    tools/ocp-build/buildActions.cmi tools/ocp-build/buildActionInit.cmo \
-    tools/ocp-build/buildActionBuild.cmi
-tools/ocp-build/buildActionBuild.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-config/simpleConfig.cmx libs/ocplib-unix/minUnix.cmx \
-    libs/ocplib-file/file.cmx libs/ocplib-debug/debugVerbosity.cmx \
-    tools/ocp-build/buildVersion.cmx tools/ocp-build/buildValue.cmx \
-    tools/ocp-build/buildUninstall.cmx tools/ocp-build/buildTypes.cmx \
-    tools/ocp-build/buildTerm.cmx tools/ocp-build/buildSubst.cmx \
-    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildOasis.cmx \
-    tools/ocp-build/buildOCamlVariables.cmx \
-    tools/ocp-build/buildOCamlRules.cmx tools/ocp-build/buildOCamlMeta.cmx \
-    tools/ocp-build/buildOCamlInstall.cmx \
-    tools/ocp-build/buildOCamlConfig.cmx tools/ocp-build/buildOCPTypes.cmx \
-    tools/ocp-build/buildOCPTree.cmx tools/ocp-build/buildOCPPrinter.cmx \
-    tools/ocp-build/buildOCPInterp.cmx tools/ocp-build/buildOCP.cmx \
-    tools/ocp-build/buildMtime.cmx tools/ocp-build/buildMisc.cmx \
-    tools/ocp-build/buildGlobals.cmx tools/ocp-build/buildEngineTypes.cmx \
-    tools/ocp-build/buildEngineRules.cmx \
-    tools/ocp-build/buildEngineDisplay.cmx \
-    tools/ocp-build/buildEngineContext.cmx tools/ocp-build/buildEngine.cmx \
-    tools/ocp-build/buildConfig.cmx tools/ocp-build/buildArgs.cmx \
-    tools/ocp-build/buildActions.cmx tools/ocp-build/buildActionInit.cmx \
-    tools/ocp-build/buildActionBuild.cmi
-tools/ocp-build/buildActionInstall.cmo : libs/ocplib-lang/stringSet.cmi \
-    libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/buildValue.cmi tools/ocp-build/buildUninstall.cmi \
-    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildTerm.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlInstall.cmi \
-    tools/ocp-build/buildMisc.cmo tools/ocp-build/buildArgs.cmo \
-    tools/ocp-build/buildActions.cmi tools/ocp-build/buildActionBuild.cmi \
-    tools/ocp-build/buildActionInstall.cmi
-tools/ocp-build/buildActionInstall.cmx : libs/ocplib-lang/stringSet.cmx \
-    libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    tools/ocp-build/buildValue.cmx tools/ocp-build/buildUninstall.cmx \
-    tools/ocp-build/buildTypes.cmx tools/ocp-build/buildTerm.cmx \
-    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildOCamlInstall.cmx \
-    tools/ocp-build/buildMisc.cmx tools/ocp-build/buildArgs.cmx \
-    tools/ocp-build/buildActions.cmx tools/ocp-build/buildActionBuild.cmx \
-    tools/ocp-build/buildActionInstall.cmi
-tools/ocp-build/buildActionClean.cmo : libs/ocplib-file/file.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildArgs.cmo \
-    tools/ocp-build/buildActions.cmi
-tools/ocp-build/buildActionClean.cmx : libs/ocplib-file/file.cmx \
-    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildArgs.cmx \
-    tools/ocp-build/buildActions.cmx
-tools/ocp-build/buildActionTests.cmo : tools/ocp-build/buildTypes.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlTest.cmi \
-    tools/ocp-build/buildArgs.cmo tools/ocp-build/buildActions.cmi \
-    tools/ocp-build/buildActionBuild.cmi tools/ocp-build/buildActionTests.cmi
-tools/ocp-build/buildActionTests.cmx : tools/ocp-build/buildTypes.cmx \
-    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildOCamlTest.cmx \
-    tools/ocp-build/buildArgs.cmx tools/ocp-build/buildActions.cmx \
-    tools/ocp-build/buildActionBuild.cmx tools/ocp-build/buildActionTests.cmi
-tools/ocp-build/buildActionUninstall.cmo : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/buildUninstall.cmi tools/ocp-build/buildGlobals.cmo \
-    tools/ocp-build/buildArgs.cmo
-tools/ocp-build/buildActionUninstall.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    tools/ocp-build/buildUninstall.cmx tools/ocp-build/buildGlobals.cmx \
-    tools/ocp-build/buildArgs.cmx
-tools/ocp-build/buildActionQuery.cmo : tools/ocp-build/buildTypes.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCPTypes.cmi \
+    libs/ocplib-config/simpleConfig.cmi libs/ocplib-file/file.cmi \
+    libs/ocplib-file/dir.cmi tools/ocp-build/buildVersion.cmo \
     tools/ocp-build/buildOCP.cmi tools/ocp-build/buildMisc.cmo \
-    tools/ocp-build/buildArgs.cmo tools/ocp-build/buildActions.cmi \
-    tools/ocp-build/buildActionBuild.cmi
-tools/ocp-build/buildActionQuery.cmx : tools/ocp-build/buildTypes.cmx \
-    tools/ocp-build/buildOptions.cmx tools/ocp-build/buildOCPTypes.cmx \
+    tools/ocp-build/buildOptions.cmi
+tools/ocp-build/buildOptions.cmx : libs/ocplib-lang/stringSet.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-config/simpleConfig.cmx libs/ocplib-file/file.cmx \
+    libs/ocplib-file/dir.cmx tools/ocp-build/buildVersion.cmx \
     tools/ocp-build/buildOCP.cmx tools/ocp-build/buildMisc.cmx \
-    tools/ocp-build/buildArgs.cmx tools/ocp-build/buildActions.cmx \
-    tools/ocp-build/buildActionBuild.cmx
-tools/ocp-build/buildActionHelp.cmo : libs/ocplib-lang/stringMap.cmi \
+    tools/ocp-build/buildOptions.cmi
+tools/ocp-build/buildOptions.cmi : libs/ocplib-config/simpleConfig.cmi \
+    libs/ocplib-file/file.cmi
+tools/ocp-build/buildScanner.cmo : libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/buildOCPInterp.cmi tools/ocp-build/buildMisc.cmo \
-    tools/ocp-build/buildArgs.cmo
-tools/ocp-build/buildActionHelp.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-file/fileString.cmi tools/ocp-build/buildScanner.cmi
+tools/ocp-build/buildScanner.cmx : libs/ocplib-lang/stringMap.cmx \
     libs/ocplib-compat/string-compat/stringCompat.cmx \
-    tools/ocp-build/buildOCPInterp.cmx tools/ocp-build/buildMisc.cmx \
-    tools/ocp-build/buildArgs.cmx
-tools/ocp-build/buildMain.cmo : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/buildMisc.cmo \
-    tools/ocp-build/buildGlobals.cmo tools/ocp-build/buildArgs.cmo \
-    tools/ocp-build/buildActions.cmi tools/ocp-build/buildActionUninstall.cmo \
-    tools/ocp-build/buildActionTests.cmi tools/ocp-build/buildActionQuery.cmo \
-    tools/ocp-build/buildActionPrefs.cmo \
-    tools/ocp-build/buildActionInstall.cmi \
-    tools/ocp-build/buildActionInit.cmo tools/ocp-build/buildActionHelp.cmo \
-    tools/ocp-build/buildActionConfigure.cmo \
-    tools/ocp-build/buildActionClean.cmo tools/ocp-build/buildActionBuild.cmi
-tools/ocp-build/buildMain.cmx : libs/ocplib-lang/stringMap.cmx \
-    libs/ocplib-compat/string-compat/stringCompat.cmx \
-    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/buildMisc.cmx \
-    tools/ocp-build/buildGlobals.cmx tools/ocp-build/buildArgs.cmx \
-    tools/ocp-build/buildActions.cmx tools/ocp-build/buildActionUninstall.cmx \
-    tools/ocp-build/buildActionTests.cmx tools/ocp-build/buildActionQuery.cmx \
-    tools/ocp-build/buildActionPrefs.cmx \
-    tools/ocp-build/buildActionInstall.cmx \
-    tools/ocp-build/buildActionInit.cmx tools/ocp-build/buildActionHelp.cmx \
-    tools/ocp-build/buildActionConfigure.cmx \
-    tools/ocp-build/buildActionClean.cmx tools/ocp-build/buildActionBuild.cmx
-libs/ocplib-debug/debugVerbosity.cmi :
-libs/ocplib-debug/debugTyperex.cmi :
-libs/ocplib-lang/ocpPervasives.cmi :
-libs/ocplib-lang/ocpList.cmi :
-libs/ocplib-lang/ocpString.cmi :
-libs/ocplib-lang/ocpStream.cmi :
-libs/ocplib-lang/ocpGenlex.cmi :
-libs/ocplib-lang/ocpHashtbl.cmi :
-libs/ocplib-lang/ocpDigest.cmi :
-libs/ocplib-lang/ocpArray.cmi :
-libs/ocplib-lang/option.cmi :
-libs/ocplib-lang/intMap.cmi :
-libs/ocplib-lang/intSet.cmi :
-libs/ocplib-lang/stringMap.cmi :
-libs/ocplib-lang/stringSet.cmi :
-libs/ocplib-lang/toposort.cmi :
-libs/ocplib-lang/linearToposort.cmi :
-libs/ocplib-lang/ocamllexer.cmi :
-libs/ocplib-lang/trie.cmi :
-libs/ocplib-lang/ocpLang.cmi : libs/ocplib-lang/ocpString.cmi \
-    libs/ocplib-lang/ocpStream.cmi libs/ocplib-lang/ocpPervasives.cmi \
-    libs/ocplib-lang/ocpList.cmi libs/ocplib-lang/ocpHashtbl.cmi \
-    libs/ocplib-lang/ocpGenlex.cmi libs/ocplib-lang/ocpDigest.cmi
-libs/ocplib-lang/stringSubst.cmi :
-libs/ocplib-lang/manpage.cmi :
-libs/ocplib-lang/stringTemplate.cmi :
-libs/ocplib-lang/reentrantBuffers.cmi : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo
-libs/ocplib-unix/minUnix.cmi :
-libs/ocplib-unix/onlyUnix.cmi : libs/ocplib-unix/minUnix.cmi
-libs/ocplib-unix/onlyWin32.cmi : libs/ocplib-unix/minUnix.cmi
-libs/ocplib-file/fileOS.cmi :
-libs/ocplib-file/fileChannel.cmi : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-file/fileSig.cmo
-libs/ocplib-file/fileString.cmi : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-file/fileSig.cmo
-libs/ocplib-file/fileLines.cmi :
-libs/ocplib-file/file.cmi : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-file/fileSig.cmo
-libs/ocplib-file/dir.cmi : libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-file/file.cmi
-libs/ocplib-system/date.cmi : libs/ocplib-unix/minUnix.cmi
-libs/ocplib-system/ocpUnix.cmi :
-libs/ocplib-system/ocpFilename.cmi :
-libs/ocplib-system/debug.cmi :
-libs/ocplib-system/fileTemplate.cmi :
-libs/ocplib-config/pythonConfig.cmi : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-file/file.cmi
-libs/ocplib-config/simpleConfigOCaml.cmi : \
-    libs/ocplib-config/simpleConfigTypes.cmo libs/ocplib-file/file.cmi
-libs/ocplib-config/simpleConfig.cmi : libs/ocplib-lang/intMap.cmi \
-    libs/ocplib-file/file.cmi
-tools/ocp-build/buildMtime.cmi :
+    libs/ocplib-file/fileString.cmx tools/ocp-build/buildScanner.cmi
 tools/ocp-build/buildScanner.cmi : libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo
+tools/ocp-build/buildSubst.cmo : libs/ocplib-lang/stringSubst.cmi \
+    libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
+    tools/ocp-build/buildSubst.cmi
+tools/ocp-build/buildSubst.cmx : libs/ocplib-lang/stringSubst.cmx \
+    libs/ocplib-lang/ocpString.cmx libs/ocplib-unix/minUnix.cmx \
+    tools/ocp-build/buildSubst.cmi
 tools/ocp-build/buildSubst.cmi : libs/ocplib-lang/stringSubst.cmi
-tools/ocp-build/buildFind.cmi :
+tools/ocp-build/buildTerm.cmo : libs/ocplib-lang/ocpString.cmi \
+    libs/ocplib-unix/minUnix.cmi tools/ocp-build/buildMisc.cmo \
+    tools/ocp-build/buildTerm.cmi
+tools/ocp-build/buildTerm.cmx : libs/ocplib-lang/ocpString.cmx \
+    libs/ocplib-unix/minUnix.cmx tools/ocp-build/buildMisc.cmx \
+    tools/ocp-build/buildTerm.cmi
 tools/ocp-build/buildTerm.cmi :
-tools/ocp-build/ocamldot.cmi :
-tools/ocp-build/buildValue.cmi : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo
-tools/ocp-build/versioning.cmi :
-tools/ocp-build/buildOCPTypes.cmi : libs/ocplib-lang/stringMap.cmi \
+tools/ocp-build/buildTypes.cmo : libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/linearToposort.cmi libs/ocplib-lang/intMap.cmi \
-    tools/ocp-build/buildValue.cmi
-tools/ocp-build/buildOCPTree.cmi : tools/ocp-build/buildOCPTypes.cmi
-tools/ocp-build/buildOCPParser.cmi : tools/ocp-build/buildOCPTree.cmi
-tools/ocp-build/buildOCPParse.cmi : tools/ocp-build/buildOCPTree.cmi
-tools/ocp-build/buildOCPPrinter.cmi : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/buildValue.cmi tools/ocp-build/buildOCPTypes.cmi
-tools/ocp-build/buildOCPInterp.cmi : libs/ocplib-lang/stringSubst.cmi \
-    libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/buildValue.cmi tools/ocp-build/buildOCPTypes.cmi
-tools/ocp-build/buildOCP.cmi : libs/ocplib-file/file.cmi \
-    tools/ocp-build/buildOCPTypes.cmi tools/ocp-build/buildOCPInterp.cmi
-tools/ocp-build/buildEngineTypes.cmi : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/intMap.cmi libs/ocplib-file/file.cmi \
-    tools/ocp-build/buildMtime.cmi
-tools/ocp-build/buildEngineGlobals.cmi : \
-    tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildEngineContext.cmi : \
-    tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildEngineDisplay.cmi : \
-    tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildEngine.cmi : tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildObjectInspector.cmi :
+    libs/ocplib-lang/linearToposort.cmi libs/ocplib-file/file.cmi \
+    tools/ocp-build/buildValue.cmi tools/ocp-build/buildOCPTypes.cmi \
+    tools/ocp-build/buildEngineTypes.cmi tools/ocp-build/buildTypes.cmi
+tools/ocp-build/buildTypes.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/linearToposort.cmx libs/ocplib-file/file.cmx \
+    tools/ocp-build/buildValue.cmx tools/ocp-build/buildOCPTypes.cmx \
+    tools/ocp-build/buildEngineTypes.cmx tools/ocp-build/buildTypes.cmi
 tools/ocp-build/buildTypes.cmi : libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo \
     libs/ocplib-lang/linearToposort.cmi libs/ocplib-file/file.cmi \
     tools/ocp-build/buildValue.cmi tools/ocp-build/buildOCPTypes.cmi \
     tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildOptions.cmi : libs/ocplib-config/simpleConfig.cmi \
-    libs/ocplib-file/file.cmi
-tools/ocp-build/buildConfig.cmi :
+tools/ocp-build/buildUninstall.cmo : libs/ocplib-lang/stringSet.cmi \
+    libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/ocpString.cmi libs/ocplib-unix/minUnix.cmi \
+    libs/ocplib-file/fileLines.cmi tools/ocp-build/buildScanner.cmi \
+    tools/ocp-build/buildUninstall.cmi
+tools/ocp-build/buildUninstall.cmx : libs/ocplib-lang/stringSet.cmx \
+    libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/ocpString.cmx libs/ocplib-unix/minUnix.cmx \
+    libs/ocplib-file/fileLines.cmx tools/ocp-build/buildScanner.cmx \
+    tools/ocp-build/buildUninstall.cmi
 tools/ocp-build/buildUninstall.cmi :
-tools/ocp-build/buildAutogen.cmi : libs/ocplib-file/file.cmi \
-    tools/ocp-build/buildOCPTypes.cmi
+tools/ocp-build/buildValue.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/buildValue.cmi
+tools/ocp-build/buildValue.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    tools/ocp-build/buildValue.cmi
+tools/ocp-build/buildValue.cmi : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo
+tools/ocp-build/buildVersion.cmo :
+tools/ocp-build/buildVersion.cmx :
+tools/ocp-build/buildWarnings.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/buildWarnings.cmi
+tools/ocp-build/buildWarnings.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    tools/ocp-build/buildWarnings.cmi
+tools/ocp-build/buildWarnings.cmi :
+tools/ocp-build/logger.cmo :
+tools/ocp-build/logger.cmx :
+tools/ocp-build/metaConfig.cmo : libs/ocplib-lang/ocpString.cmi \
+    tools/ocp-build/buildMisc.cmo tools/ocp-build/metaConfig.cmi
+tools/ocp-build/metaConfig.cmx : libs/ocplib-lang/ocpString.cmx \
+    tools/ocp-build/buildMisc.cmx tools/ocp-build/metaConfig.cmi
+tools/ocp-build/metaConfig.cmi :
+tools/ocp-build/metaFile.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/metaTypes.cmi tools/ocp-build/metaFile.cmi
+tools/ocp-build/metaFile.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    tools/ocp-build/metaTypes.cmx tools/ocp-build/metaFile.cmi
+tools/ocp-build/metaFile.cmi : tools/ocp-build/metaTypes.cmi
+tools/ocp-build/metaLexer.cmo : tools/ocp-build/metaLexer.cmi
+tools/ocp-build/metaLexer.cmx : tools/ocp-build/metaLexer.cmi
+tools/ocp-build/metaLexer.cmi :
+tools/ocp-build/metaParser.cmo : \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    libs/ocplib-lang/ocpString.cmi tools/ocp-build/metaTypes.cmi \
+    tools/ocp-build/metaLexer.cmi tools/ocp-build/metaFile.cmi \
+    libs/ocplib-debug/debugVerbosity.cmi tools/ocp-build/metaParser.cmi
+tools/ocp-build/metaParser.cmx : \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    libs/ocplib-lang/ocpString.cmx tools/ocp-build/metaTypes.cmx \
+    tools/ocp-build/metaLexer.cmx tools/ocp-build/metaFile.cmx \
+    libs/ocplib-debug/debugVerbosity.cmx tools/ocp-build/metaParser.cmi
+tools/ocp-build/metaParser.cmi : tools/ocp-build/metaTypes.cmi
+tools/ocp-build/metaTypes.cmo : libs/ocplib-lang/stringMap.cmi \
+    libs/ocplib-compat/string-compat/stringCompat.cmo \
+    tools/ocp-build/metaTypes.cmi
+tools/ocp-build/metaTypes.cmx : libs/ocplib-lang/stringMap.cmx \
+    libs/ocplib-compat/string-compat/stringCompat.cmx \
+    tools/ocp-build/metaTypes.cmi
 tools/ocp-build/metaTypes.cmi : libs/ocplib-lang/stringMap.cmi \
     libs/ocplib-compat/string-compat/stringCompat.cmo
-tools/ocp-build/metaLexer.cmi :
-tools/ocp-build/metaFile.cmi : tools/ocp-build/metaTypes.cmi
-tools/ocp-build/metaParser.cmi : tools/ocp-build/metaTypes.cmi
-tools/ocp-build/metaConfig.cmi :
-tools/ocp-build/buildOCamlConfig.cmi : tools/ocp-build/buildValue.cmi \
-    tools/ocp-build/buildOptions.cmi
-tools/ocp-build/buildOCamlTypes.cmi : libs/ocplib-lang/stringMap.cmi \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    libs/ocplib-lang/intMap.cmi tools/ocp-build/buildValue.cmi \
-    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildOCamldep.cmi : tools/ocp-build/buildValue.cmi \
-    tools/ocp-build/buildOCamlTypes.cmi tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildOCamlSyntaxes.cmi : tools/ocp-build/buildValue.cmi \
-    tools/ocp-build/buildOCamlTypes.cmi tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildOCamlInstall.cmi : tools/ocp-build/buildTypes.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlConfig.cmi
-tools/ocp-build/buildOCamlRules.cmi : tools/ocp-build/buildTypes.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlConfig.cmi \
-    tools/ocp-build/buildOCPTypes.cmi
-tools/ocp-build/buildOCamlMeta.cmi : tools/ocp-build/buildOCPInterp.cmi
-tools/ocp-build/buildOCamlTest.cmi : tools/ocp-build/buildTypes.cmi \
-    tools/ocp-build/buildEngineTypes.cmi
-tools/ocp-build/buildOasis.cmi : tools/ocp-build/buildOCPInterp.cmi
-tools/ocp-build/buildActions.cmi : libs/ocplib-file/file.cmi \
-    tools/ocp-build/buildOptions.cmi tools/ocp-build/buildOCamlConfig.cmi
-tools/ocp-build/buildActionBuild.cmi : \
-    libs/ocplib-compat/string-compat/stringCompat.cmo \
-    tools/ocp-build/buildTypes.cmi tools/ocp-build/buildOptions.cmi \
-    tools/ocp-build/buildOCPInterp.cmi tools/ocp-build/buildArgs.cmo \
-    tools/ocp-build/buildActions.cmi
-tools/ocp-build/buildActionInstall.cmi : tools/ocp-build/buildArgs.cmo
-tools/ocp-build/buildActionTests.cmi : tools/ocp-build/buildArgs.cmo
+tools/ocp-build/ocamldot.cmo : tools/ocp-build/ocamldot.cmi
+tools/ocp-build/ocamldot.cmx : tools/ocp-build/ocamldot.cmi
+tools/ocp-build/ocamldot.cmi :
+tools/ocp-build/versioning.cmo : tools/ocp-build/versioning.cmi
+tools/ocp-build/versioning.cmx : tools/ocp-build/versioning.cmi
+tools/ocp-build/versioning.cmi :

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ OCPLIB_CONFIG= $(config_SRCDIR)/pythonConfig.ml \
 
 BUILD_MISC= $(OCP_BUILD_SRCDIR)/logger.ml				\
     $(OCP_BUILD_SRCDIR)/buildMisc.ml					\
+    $(OCP_BUILD_SRCDIR)/buildWarnings.ml				\
     $(OCP_BUILD_SRCDIR)/buildMtime.ml					\
     $(OCP_BUILD_SRCDIR)/buildScanner.ml					\
     $(OCP_BUILD_SRCDIR)/buildSubst.ml					\
@@ -115,6 +116,7 @@ BUILD_OCAML= $(OCP_BUILD_SRCDIR)/buildOCamlConfig.ml	\
 
 BUILD_MAIN= $(OCP_BUILD_SRCDIR)/buildArgs.ml	\
     $(OCP_BUILD_SRCDIR)/buildActions.ml		\
+    $(OCP_BUILD_SRCDIR)/buildActionsWarnings.ml	\
     $(OCP_BUILD_SRCDIR)/buildActionInit.ml	\
     $(OCP_BUILD_SRCDIR)/buildActionPrefs.ml	\
     $(OCP_BUILD_SRCDIR)/buildActionConfigure.ml	\
@@ -156,8 +158,10 @@ all: build-ocps
 	@echo Libraries will be installed in ${ocamldir}
 	@echo META files will be installed in ${metadir}
 
-build-ocps: $(OCP_BUILD_BOOTER)
+_obuild: Makefile
 	$(OCP_BUILD_BOOTER) init
+
+build-ocps: $(OCP_BUILD_BOOTER) _obuild
 	$(OCP_BUILD_BOOTER)
 
 depend: $(OCP_BUILD_MLS) $(OCP_BUILD_TMPS)

--- a/tools/ocp-autoconf/autoconfAutoconf.ml
+++ b/tools/ocp-autoconf/autoconfAutoconf.ml
@@ -61,7 +61,8 @@ let () =
            | _ ->
              need_pkgs := pkg :: !need_pkgs
          ) !!need_packages;
-       if !!optional_packages <> [] then need_ocamlfind := true;
+       if !!optional_packages <> [] || !!need_packages <> [] then
+         need_ocamlfind := true;
 
        let need_packages = List.rev !need_pkgs in
 

--- a/tools/ocp-build/build.ocp
+++ b/tools/ocp-build/build.ocp
@@ -27,23 +27,24 @@ version = package_version
 install = false
 
 begin library "ocp-build-misc"
-  install = true
+  install = true;
   files = [
     "logger.ml"
+    "ocamldot.ml"
+    "versioning.ml"
+
     "buildMisc.ml";
     "buildMtime.ml";      (* How modification times are computed *)
 
     "buildScanner.ml"; (* Scan directories looking for files with particular properties *)
-    "buildSubst.ml"
-      "buildFind.ml"
-    "buildTerm.ml"
-    "ocamldot.ml"
-    "buildValue.ml"
-    "versioning.ml"
-  ]
+    "buildSubst.ml";
+    "buildFind.ml";
+    "buildTerm.ml";
+    "buildValue.ml";
+    "buildWarnings.ml";
+  ];
 
-   requires =  [
-    "ocplib-lang"; "ocplib-unix" "ocplib-system" ]
+  requires =  [ "ocplib-lang"; "ocplib-unix" "ocplib-system" ];
 
 end
 
@@ -167,6 +168,7 @@ begin program "ocp-build"
   files = [
     "buildArgs.ml"
     "buildActions.ml";          (* Main possible actions *)
+    "buildActionsWarnings.ml";          (* Main possible actions *)
     "buildActionInit.ml"
     "buildActionPrefs.ml"
     "buildActionConfigure.ml"

--- a/tools/ocp-build/buildActionBuild.ml
+++ b/tools/ocp-build/buildActionBuild.ml
@@ -51,12 +51,22 @@ open BuildValue.Types
 
 let verbose = DebugVerbosity.verbose ["B"] "BuildActionBuild"
 
+  (*
+  if
+    !build_max ||
+      (!targets_arg <> []
+       && List.for_all
+         (fun (name,_) -> not (List.mem name !targets_arg)) missing
+       && List.for_all
+         (fun pk -> not (List.mem pk.package_name !targets_arg))
+         (Array.to_list pj.project_incomplete))
+  then []
+  else
+  *)
+
 let max_stage = ref 20
 
 let build_max = ref false
-
-let arg_ocp_dirs = ref []
-let load_installed_ocp = ref true
 
 let make_build_targets = ref false
 let make_doc_targets = ref false
@@ -74,362 +84,16 @@ let print_installed install_where =
 
 let move_to_project = ref true
 
+  (*
 let finally_do = ref []
 let add_finally action =
   finally_do := action :: !finally_do
-
-let do_load_project_files cin project_dir state =
-  let open ProjectOptions in
-
-  let force_scan = ref cin.cin_autoscan in
-
-  (* if we didn't find any .ocp files before, we should retry ! *)
-  if !!root_files = [] then force_scan := true;
-
-  if ! add_external_projects_arg <> [] then begin
-    List.iter (fun dir ->
-      if not (List.mem dir !!project_external_dirs_option) then begin
-        must_save_project ();
-        project_external_dirs_option =:= !!project_external_dirs_option @
-            [ dir ];
-        force_scan := true;
-      end
-    ) (List.rev !add_external_projects_arg)
-  end;
-
-  if !!project_ocpbuild_version != BuildVersion.version then begin
-    must_save_project ();
-    project_ocpbuild_version =:= BuildVersion.version;
-  end;
-
-  let nerrors =
-    if !oasis_arg then
-      BuildOasis.load_project state "_oasis"
-    else
-      begin
-      if !force_scan then begin
-        save_project := true;
-        time_step "Scanning project for .ocp files ...";
-        root_files =:= [];
-        List.iter (fun dir ->
-          let files = BuildOCP.scan_root dir in
-          root_files =:= !!root_files @ files
-        ) (project_dir ::
-            (List.map File.of_string !!project_external_dirs_option));
-        time_step "   Done scanning project for .ocp files";
-      end;
-
-      if !!root_files = [] then begin
-        Printf.eprintf "Error: no known .ocp files\n";
-        Printf.eprintf "\tHave you run ocp-build with -scan to find them ?\n%!";
-        BuildMisc.clean_exit 2
-      end;
-
-      time_step "Loading project .ocp files...";
-      let nerrors =
-        let config = BuildOCP.empty_config () in
-        BuildOCP.load_ocp_files config state !!root_files
-      in
-      time_step "   Done loading project .ocp files";
-      nerrors
-      end
-  in
-  if nerrors > 0 then BuildMisc.clean_exit 2
-
-
-let do_print_project_info pj =
-
-  BuildOCP.print_conflicts pj !print_conflicts_arg;
-  let string_of_package pj =
-    Printf.sprintf "   %s (%s,%s)\n     in %s\n"
-      pj.package_name
-      (BuildOCPTree.string_of_package_type pj.package_type)
-      pj.package_source_kind
-      pj.package_dirname
-  in
-  let print_package pj =
-    Printf.eprintf "%s\tdeps:" (string_of_package pj);
-    List.iter (fun s ->
-      Printf.eprintf " %s" s;
-    ) (BuildValue.get_strings_with_default [pj.package_options] "requires" []);
-    Printf.eprintf "\n%!";
-  in
-  if verbose 5 || !list_projects_arg then begin
-
-    let print_package_array array =
-      let list = ref [] in
-      Array.iter (fun pj ->
-        list := string_of_package pj :: !list) array;
-      List.iter (fun s ->
-        Printf.printf "%s%!" s)
-        (List.sort compare !list)
-    in
-
-    Printf.eprintf "Validated packages:\n";
-    print_package_array pj.project_sorted;
-
-    Printf.eprintf "Disabled packages:\n";
-    print_package_array pj.project_disabled;
-
-  end;
-
-  begin
-    let incomplete_packages = Hashtbl.create  13 in
-    if pj.project_incomplete <> [||] then begin
-      Printf.eprintf "Warning: %d incomplete packages (will not be built):\n"
-        (Array.length pj.project_incomplete);
-      let meta_need = ref 0 in
-      Array.iter (fun pk ->
-        Hashtbl.add incomplete_packages pk.package_name pk;
-        if !meta_verbose_arg ||
-           pk.package_source_kind <> "meta" then (* TODO ? *)
-          print_package pk
-        else
-          incr meta_need
-      )
-        pj.project_incomplete;
-      if !meta_need > 0 then
-        Printf.eprintf
-          "  Hidden: %d incomplete packages in META files (use -print-incomplete-meta).\n%!" !meta_need
-    end;
-
-    if pj.project_missing <> [] then
-      let absent_packages = ref [] in
-      let other_packages = ref [] in
-      List.iter (fun (name, list) ->
-        let non_meta_need = ref false in
-        if !meta_verbose_arg then
-          non_meta_need := true
-        else
-          List.iter (fun pk ->
-            if pk.package_source_kind <> "meta" then non_meta_need := true
-          ) list;
-        if !non_meta_need then begin
-          let packages =
-            if Hashtbl.mem incomplete_packages name then
-              other_packages else absent_packages in
-          packages := (name, list) :: !packages
-        end;
-      ) pj.project_missing;
-      if !absent_packages <> [] then begin
-        Printf.eprintf "Warning: %d needed packages are missing !\n%!"
-          (List.length !absent_packages);
-        List.iter (fun (name, list) ->
-          Printf.eprintf "   ABSENT package %S missed by %d packages\n"
-            name (List.length list);
-          List.iter print_package list;
-        ) !absent_packages
-      end;
-      List.iter (fun (name, list) ->
-        Printf.eprintf "   Incomplete package %S missed by %d packages\n"
-          name
-          (List.length list);
-        List.iter print_package list;
-      ) !other_packages
-
-  end
-
-(* TODO: we should return two lists:
-  * the list of targets that can be built
-  * the list of targets that cannot be built
- *)
-
-let do_print_fancy_project_info pj =
-  BuildOCP.print_conflicts pj !print_conflicts_arg;
-
-  let cantbuild = [] in
-  let missing =
-    List.filter
-      (fun (_name, pkgs) ->
-        List.exists (fun pk -> pk.package_source_kind <> "meta") pkgs)
-      pj.project_missing
-  in
-  (* don't complain if there is no problem with the selected targets *)
-  if
-    !build_max ||
-      (!targets_arg <> []
-       && List.for_all
-         (fun (name,_) -> not (List.mem name !targets_arg)) missing
-       && List.for_all
-         (fun pk -> not (List.mem pk.package_name !targets_arg))
-         (Array.to_list pj.project_incomplete))
-  then []
-  else
-    let missing_roots =
-    (* remove all missing pkgs that depend on another to get the missing roots *)
-      List.filter
-        (fun (name, _pkgs) ->
-          not
-            (List.exists
-               (fun (_,pks) ->
-                 List.exists (fun pk -> name = pk.package_name) pks)
-               missing))
-        missing
-    in
-    let cantbuild =
-      if missing = [] then cantbuild
-      else if missing_roots = [] then begin (* no roots ! *)
-        let rec find_cycle acc = function
-          | [] -> None
-          | name :: _ when List.mem name acc -> Some acc
-          | name :: r ->
-            let provides =
-              List.map (fun pk -> pk.package_name)
-                (try List.assoc name missing with Not_found -> [])
-            in
-            match find_cycle (name::acc) provides with
-            | Some _ as r -> r
-            | None -> find_cycle acc r
-        in
-        let cycle = List.map fst missing in
-        let cycle =
-          match find_cycle [] cycle with
-          | Some l -> l
-          | None -> assert false
-        in
-      (*TODO: these are only errors if the corresponding packages have
-        been specified as targets. *)
-        Printf.eprintf
-          "%sERROR%s: circular dependency between:\n"
-          term.esc_red_text term.esc_end;
-        List.iter
-          (fun (n1,n2) -> Printf.eprintf "  - %s%s%s depends on %s\n"
-            term.esc_bold n1 term.esc_end n2)
-          (List.combine cycle (List.tl cycle @ [List.hd cycle]));
-        cycle @ cantbuild
-      end else begin
-        Printf.eprintf
-          "%sERROR%s: the following packages are %smissing%s:\n"
-          term.esc_red_text term.esc_end  term.esc_bold term.esc_end;
-        List.iter (fun (name,_) ->
-          Printf.eprintf "  - %s%s%s\n" term.esc_bold name term.esc_end
-        ) missing_roots;
-        List.map fst missing_roots @ cantbuild
-      end
-    in
-    let cantbuild =
-      if pj.project_incomplete = [||] then cantbuild
-      else begin
-        let additional =
-          List.filter
-            (fun pk -> pk.package_source_kind <> "meta"
-              && not (List.mem pk.package_name cantbuild))
-            (Array.to_list pj.project_incomplete)
-        in
-        if additional <> [] then
-          Printf.eprintf
-            "Additional packages %s can't be built.\n"
-            (String.concat ", "
-               (List.map (fun pk -> Printf.sprintf "%s%s%s"
-                 term.esc_bold pk.package_name term.esc_end)
-                  additional));
-        List.map (fun pk -> pk.package_name) additional @ cantbuild
-      end
-    in
-    cantbuild
-
-let print_build_context = ref false
-let do_init_project_building p pj =
-  let build_dir_basename = !build_dir_basename_arg in
-
-  let build_dir_filename = (* absolute_filename *) build_dir_basename in
-
-  let build_dir_filename =
-    match !arch_arg with
-    | Arch host -> Filename.concat build_dir_filename host
-    | ArchNone -> build_dir_filename
-  in
-
-  BuildMisc.safe_mkdir build_dir_filename;
-
-  time_step "Saving raw project info...";
-  BuildOCP.save_project_state pj
-    (File.add_basename (File.of_string build_dir_filename) "ocp.ocpx");
-  time_step "   Done saving raw project info";
-
-  let b =
-    BuildEngineContext.create (File.to_string p.project_dir)
-      build_dir_filename in
-
-  begin match p.cout.cout_ocamlbin with
-  | None -> ()
-  | Some ocamlbin ->
-    ignore (BuildEngineContext.add_directory b ocamlbin);
-  end;
-
-  let bc = new_builder_context b in
-  b.stop_on_error_arg <- !stop_on_error_arg;
-
-  let packages = BuildOCamlRules.create p.cin p.cout bc pj in
-
-  if !print_build_context then
-    BuildEngineDisplay.eprint_context b;
-  (bc, packages)
-
-
-
-let chdir_to_project p =
-  let dir = File.to_string p.project_dir in
-  if MinUnix.getcwd () <> dir then begin
-    BuildMisc.chdir dir;
-    Printf.fprintf stdout "ocp-build: Entering directory `%s'\n%!"
-      (File.to_string p.project_dir);
-(* TODO: move at_exit to add_finally *)
-    let final_handler_executed = ref false in
-    let final_handler () =
-      if not !final_handler_executed then begin
-        final_handler_executed := true;
-        Printf.printf
-          "ocp-build: Leaving directory `%s'\n%!"
-          (File.to_string p.project_dir)
-      end
-    in
-    add_finally final_handler;
-    at_exit final_handler
-  end;
-  ()
-
-
-let load_initial_project p state targets =
-
-  do_load_project_files p.cin p.project_dir state;
-
-  (*    end; *)
-
-  (* [ocp-build configure] stops here, so it will not scan
-     for .ocp files at this point. Instead, it will be done the
-     first time the project is compiled, because [root_files] is
-     empty. *)
-
-  if !configure_arg then save_project := true;
-
-  if !save_project then begin
-    Printf.fprintf stderr "Updating ocp-build.root\n%!";
-    BuildOptions.must_save_project ()
-  end;
-
-
-  if !conf_arg || !distrib_arg || !autogen_arg then BuildMisc.clean_exit 0;
-
-  let use_digests = p.cin.cin_digest in
-
-  if use_digests then BuildMtime.use_digests true;
-
-  time_step "Sorting packages...";
-  let pj = BuildOCP.verify_packages state in
-
-  time_step "   Done sorting packages";
-
-  (*
-    do_reply_to_queries pj;
   *)
 
-  if !query_global then begin
-    Printf.eprintf "Error: reached query-global end point.\n%!";
-    BuildMisc.clean_exit 0
-  end;
 
-  BuildOptions.maybe_save ();
+
+
+let rec do_compile stage p ncores env_state arg_targets pre_w bc package_map =
 
   if !configure_arg then BuildMisc.clean_exit 0;
 
@@ -440,30 +104,12 @@ let load_initial_project p state targets =
     BuildMisc.clean_exit 0;
   end;
 
-  if verbose 1 && term.esc_ansi then begin
-    let cantbuild = do_print_fancy_project_info pj in
-    if cantbuild <> [] then begin
-      BuildMisc.non_fatal_errors :=
-        "Some package dependencies are missing" :: !BuildMisc.non_fatal_errors
-    end
-  end
-  else
-    do_print_project_info pj;
+  bc.build_context.stop_on_error_arg <- !stop_on_error_arg;
 
-  let (bc, packages) = do_init_project_building p pj in
-
-  let package_map =
-    let h = ref StringMap.empty in
-    Array.iter (fun p ->
-      let module P = (val p : Package) in
-      h := StringMap.add P.name p !h;
-    ) packages;
-    !h
-  in
   let projects =
     (* build the list of projects considered by the current command *)
     let projects = ref [] in
-    match targets with
+    match arg_targets with
       [] ->
         StringMap.iter (fun _ pj ->
           projects := pj :: !projects) package_map;
@@ -481,33 +127,6 @@ let load_initial_project p state targets =
       !projects
   in
 
-  (*
-  let packages2 =
-    let projects = ref [] in
-    StringMap.iter (fun _ pj ->
-      projects := pj :: !projects) bc.packages_by_name;
-    Array.of_list !projects
-  in
-  begin
-    let packages1 = Array.map (fun p ->
-      let module P = (val p : Package) in
-      P.name) packages in
-    Array.sort compare packages1;
-    Printf.eprintf "packages1: %s\n%!"
-      (String.concat "," (Array.to_list packages1));
-
-    let packages2 = Array.map (fun p -> p.lib_name) packages2 in
-    Array.sort compare packages2;
-    Printf.eprintf "packages2: %s\n%!"
-      (String.concat "," (Array.to_list packages2));
-  end;
-  *)
-  (bc, projects, package_map)
-
-let rec do_compile stage p ncores  env_state arg_targets =
-
-  let (bc, projects, package_map) = load_initial_project p
-      (BuildOCPInterp.copy_state env_state) arg_targets in
   let b = bc.build_context in
 
   (* build the list of targets *)
@@ -640,64 +259,12 @@ let rec do_compile stage p ncores  env_state arg_targets =
       BuildMisc.clean_exit 2
     end else begin
       Printf.eprintf "Some configuration files were changed. Restarting build\n%!";
-      do_compile (stage+1) p ncores  env_state arg_targets
+      let (bc, package_map) = BuildActionInit.load_initial_project pre_w p
+        (BuildOCPInterp.copy_state env_state) in
+
+      do_compile (stage+1) p ncores  env_state arg_targets pre_w bc package_map
     end else
-    (bc, projects, package_map)
-
-let do_read_env p =
-
-  let cin = p.cin in
-  let cout = p.cout in
-
-  BuildOCamlConfig.set_global_config cout;
-
-  (* Don't modify default values from now on, since they have been included
-     in the default configuration ! *)
-
-  let env_ocp_dirs = ref cin.cin_ocps_dirnames in
-  let env_ocp_files = ref [] in
-  let state = BuildOCP.init_packages () in
-  begin
-    match cout.cout_ocamllib with
-    None -> ()
-    | Some ocamllib ->
-      if cin.cin_ocps_in_ocamllib then begin
-        env_ocp_dirs := ocamllib :: !env_ocp_dirs;
-      end;
-
-      time_step "Scanning env for .ocp files...";
-      if !load_installed_ocp then
-        List.iter (fun dir ->
-          if verbose 3 then
-            Printf.eprintf "Scanning installed .ocp files in %S\n%!" dir;
-          let dir = File.of_string dir in
-          env_ocp_files := ( BuildOCP.scan_root dir) @ !env_ocp_files
-        ) (!env_ocp_dirs @ cout.cout_meta_dirnames);
-        List.iter (fun dir ->
-          if verbose 3 then
-            Printf.eprintf "Scanning installed .ocp files in %S\n%!" dir;
-          let dir = File.of_string dir in
-          env_ocp_files := ( BuildOCP.scan_root dir) @ !env_ocp_files
-        ) !arg_ocp_dirs;
-      time_step "   Done scanning env for .ocp files";
-      time_step "Loading METAs...";
-      List.iter (fun dirname ->
-        BuildOCamlMeta.load_META_files state ocamllib dirname
-      ) cout.cout_meta_dirnames;
-  end;
-
-  time_step "   Done Loading METAs";
-
-  time_step "Loading .ocp files from env...";
-
-  let _nerrors1 =
-    let config = BuildOCP.generated_config () in
-    BuildOCP.load_ocp_files config state  !env_ocp_files
-  in
-
-  time_step "   Done Loading .ocp files from env";
-
-  state
+    (p, bc, projects, package_map)
 
 let get_ncores cin =
   let ncores = cin.cin_njobs in
@@ -707,30 +274,10 @@ let get_ncores cin =
     ncores
 
 
-let print_env_arg = ref false
 (* Also called from BuildActionTests.action () *)
-let do_build p =
-  let targets = List.rev !targets_arg in
-  time_step "Arguments parsed.";
+let do_build () =
 
-  let env_state = do_read_env p in
-  let env_pj = BuildOCP.verify_packages env_state in
-  if !print_env_arg then begin
-    BuildOCPPrinter.eprint_project "Environment packages" env_pj;
-    exit 0;
-  end;
-  time_step "Environment read and checked.";
-  (* TODO: we could check that all the packages are indeed installed ! *)
-
-  BuildOCamlVariables.packages_option.set
-    (VList (Array.to_list (Array.map (fun pk ->
-        let dirname = absolute_filename pk.package_dirname in
-        List.iter (fun suffix ->
-          BuildSubst.add_to_global_subst (pk.package_name ^ suffix) dirname)
-          [ "_SRC_DIR"; "_DST_DIR"; "_FULL_SRC_DIR"; "_FULL_DST_DIR" ];
-        VPair (VString pk.package_name, VObject pk.package_options)
-      ) env_pj.project_sorted)));
-
+  let (env_w, p, env_state, env_pj) = BuildActionInit.init_env () in
 
   if !query_global then move_to_project := false;
 
@@ -745,7 +292,7 @@ let do_build p =
     BuildMisc.clean_exit 0
   end;
 
-
+  let targets = List.rev !targets_arg in
   if !uninstall_arg && targets <> [] then begin
     let state =
       let open BuildOCamlInstall in
@@ -776,9 +323,9 @@ let do_build p =
       BuildMisc.clean_exit 2
   end;
 
-  chdir_to_project p;
+  let (bc, package_map) = BuildActionInit.init_project env_w p env_state in
 
-  do_compile 0 p (get_ncores p.cin) env_state targets
+  do_compile 0 p (get_ncores p.cin) env_state targets env_w bc package_map
 
 
 let action () =
@@ -789,11 +336,11 @@ let action () =
   if !make_test_targets then make_build_targets := true;
   if !make_doc_targets then make_build_targets := true;
 
-  let p = BuildActions.load_project () in
-  let (_b, _projects, _package_map) = do_build p in
+  let (_p, _b, _projects, _package_map) = do_build () in
   ()
 
-let arg_list = [
+let arg_list =
+  [
   (* This option should be shared with -install and -tests, no ? *)
   "-arch", Arg.String (fun s ->
     arch_arg := Arch ("_other_archs/" ^ s)),
@@ -801,30 +348,19 @@ let arg_list = [
 
   "-max", Arg.Set build_max, " Build as many packages as possible";
 
-  "-I", Arg.String (fun dir ->
-    arg_ocp_dirs := !arg_ocp_dirs @ [ dir ]),
-  "DIR Include files from DIR";
-
   "-max-stage", Arg.Int (fun n -> max_stage := n),
   "NUM Maximal number of times compilation can be restarted";
   "-print-loaded-ocp-files", Arg.Set
     BuildOCP.print_loaded_ocp_files,
   " Print loaded ocp files";
- "-print-loaded-env", Arg.Set
-    print_env_arg,
- " Print the loaded environment and exit.";
  "-print-package-deps", Arg.Set
     BuildOCP.print_package_deps,
  " Print package dependencies";
  "-print-missing", Arg.Set
-    BuildOCP.print_missing_deps, " Print missing dependencies";
+   BuildOCP.print_missing_deps, " Print missing dependencies";
  "-print-conflicts", Arg.Set
     print_conflicts_arg,
  " Print conflicts between package definitions";
-   "-no-installed-ocp", Arg.Clear load_installed_ocp,
-  " Do not load installed .ocp files";
-  "-print-build-context", Arg.Set print_build_context,
-  " Print full build context";
 
   "-doc", Arg.Set make_doc_targets, " Make doc targets";
   "-test", Arg.Set make_test_targets, " Make tests targets";
@@ -843,7 +379,9 @@ let arg_list = [
   ),
   " Print version information";
 
-] @ arg_list1
+  ]
+  @ BuildActionInit.arg_list
+  @ arg_list1
 
 let add_synomyms arg_list1 synonyms =
   arg_list1 @ List.map (fun (s1, s2) ->

--- a/tools/ocp-build/buildActionBuild.mli
+++ b/tools/ocp-build/buildActionBuild.mli
@@ -28,12 +28,13 @@ val make_build_targets : bool ref
 
 
 val do_build :
-  BuildActions.project_info ->
-  BuildTypes.builder_context * (module BuildTypes.Package) list *
+  unit ->
+  BuildActions.project_info *
+    BuildTypes.builder_context * (module BuildTypes.Package) list *
   (module BuildTypes.Package) StringCompat.StringMap.t
 
-val do_read_env : BuildActions.project_info -> BuildOCPInterp.state
+(* val do_read_env : BuildActions.project_info -> BuildOCPInterp.state *)
 
 
 val get_ncores : BuildOptions.config_input -> int
-val finally_do : (unit -> unit) list ref
+(* val finally_do : (unit -> unit) list ref  *)

--- a/tools/ocp-build/buildActionInit.ml
+++ b/tools/ocp-build/buildActionInit.ml
@@ -18,12 +18,501 @@
 (*  SOFTWARE.                                                             *)
 (**************************************************************************)
 
+open StringCompat
 
 open BuildArgs
 
+open SimpleConfig.Op
 
-let arg_list = []
+open BuildEngineTypes
+open BuildTerm (* Terminal functions *)
+open BuildOptions (* cin_... *)
+open BuildOCamlConfig.TYPES
+open BuildOCPTypes
+open BuildValue.Types
+open BuildActions
+open BuildTypes
+
+let verbose = DebugVerbosity.verbose ["B"] "BuildActionInit"
+
+let do_load_project_files cin project_dir state =
+  let open BuildOptions.ProjectOptions in
+
+  let force_scan = ref cin.cin_autoscan in
+
+  (* if we didn't find any .ocp files before, we should retry ! *)
+  if !!root_files = [] then force_scan := true;
+
+  if ! add_external_projects_arg <> [] then begin
+    List.iter (fun dir ->
+      if not (List.mem dir !!project_external_dirs_option) then begin
+        must_save_project ();
+        project_external_dirs_option =:= !!project_external_dirs_option @
+            [ dir ];
+        force_scan := true;
+      end
+    ) (List.rev !add_external_projects_arg)
+  end;
+
+  if !!project_ocpbuild_version != BuildVersion.version then begin
+    must_save_project ();
+    project_ocpbuild_version =:= BuildVersion.version;
+  end;
+
+  let nerrors =
+    if !oasis_arg then
+      BuildOasis.load_project state "_oasis"
+    else
+      begin
+      if !force_scan then begin
+        save_project := true;
+        BuildActions.time_step "Scanning project for .ocp files ...";
+        root_files =:= [];
+        List.iter (fun dir ->
+          let files = BuildOCP.scan_root dir in
+          root_files =:= !!root_files @ files
+        ) (project_dir ::
+            (List.map File.of_string !!project_external_dirs_option));
+        BuildActions.time_step "   Done scanning project for .ocp files";
+      end;
+
+      if !!root_files = [] then begin
+        Printf.eprintf "Error: no known .ocp files\n";
+        Printf.eprintf "\tHave you run ocp-build with -scan to find them ?\n%!";
+        BuildMisc.clean_exit 2
+      end;
+
+      BuildActions.time_step "Loading project .ocp files...";
+      let nerrors =
+        let config = BuildOCP.empty_config () in
+        BuildOCP.load_ocp_files config state !!root_files
+      in
+      BuildActions.time_step "   Done loading project .ocp files";
+      nerrors
+      end
+  in
+  if nerrors > 0 then BuildMisc.clean_exit 2
+
+
+let do_print_project_info pj =
+
+  let string_of_package pj =
+    Printf.sprintf "   %s (%s,%s)\n     in %s\n"
+      pj.package_name
+      (BuildOCPTree.string_of_package_type pj.package_type)
+      pj.package_source_kind
+      pj.package_dirname
+  in
+  (*
+  let print_package pj =
+    Printf.eprintf "%s\tdeps:" (string_of_package pj);
+    List.iter (fun s ->
+      Printf.eprintf " %s" s;
+    ) (BuildValue.get_strings_with_default [pj.package_options] "requires" []);
+    Printf.eprintf "\n%!";
+  in
+  *)
+  if verbose 5 || !list_projects_arg then begin
+
+    let print_package_array array =
+      let list = ref [] in
+      Array.iter (fun pj ->
+        list := string_of_package pj :: !list) array;
+      List.iter (fun s ->
+        Printf.printf "%s%!" s)
+        (List.sort compare !list)
+    in
+
+    Printf.eprintf "Validated packages:\n";
+    print_package_array pj.project_sorted;
+
+    Printf.eprintf "Disabled packages:\n";
+    print_package_array pj.project_disabled;
+
+  end;
+
+  (*
+  begin
+    let incomplete_packages = Hashtbl.create  13 in
+    if pj.project_incomplete <> [||] then begin
+      Printf.eprintf "Warning: %d incomplete packages (will not be built):\n"
+        (Array.length pj.project_incomplete);
+      let meta_need = ref 0 in
+      Array.iter (fun pk ->
+        Hashtbl.add incomplete_packages pk.package_name pk;
+        if !meta_verbose_arg ||
+           pk.package_source_kind <> "meta" then (* TODO ? *)
+          print_package pk
+        else
+          incr meta_need
+      )
+        pj.project_incomplete;
+      if !meta_need > 0 then
+        Printf.eprintf
+          "  Hidden: %d incomplete packages in META files (use -print-incomplete-meta).\n%!" !meta_need
+    end;
+
+    if pj.project_missing <> [] then
+      let absent_packages = ref [] in
+      let other_packages = ref [] in
+      List.iter (fun (name, list) ->
+        let non_meta_need = ref false in
+        if !meta_verbose_arg then
+          non_meta_need := true
+        else
+          List.iter (fun pk ->
+            if pk.package_source_kind <> "meta" then non_meta_need := true
+          ) list;
+        if !non_meta_need then begin
+          let packages =
+            if Hashtbl.mem incomplete_packages name then
+              other_packages else absent_packages in
+          packages := (name, list) :: !packages
+        end;
+      ) pj.project_missing;
+      if !absent_packages <> [] then begin
+        Printf.eprintf "Warning: %d needed packages are missing !\n%!"
+          (List.length !absent_packages);
+        List.iter (fun (name, list) ->
+          Printf.eprintf "   ABSENT package %S missed by %d packages\n"
+            name (List.length list);
+          List.iter print_package list;
+        ) !absent_packages
+      end;
+      List.iter (fun (name, list) ->
+        Printf.eprintf "   Incomplete package %S missed by %d packages\n"
+          name
+          (List.length list);
+        List.iter print_package list;
+      ) !other_packages
+
+  end;
+  *)
+  ()
+
+(* TODO: we should return two lists:
+  * the list of targets that can be built
+  * the list of targets that cannot be built
+ *)
+
+let do_print_fancy_project_info pj =
+  let cantbuild = [] in
+  (*
+  let missing =
+    List.filter
+      (fun (_name, pkgs) ->
+        List.exists (fun pk -> pk.package_source_kind <> "meta") pkgs)
+      pj.project_missing
+  in
+  (* don't complain if there is no problem with the selected targets *)
+    let missing_roots =
+    (* remove all missing pkgs that depend on another to get the missing roots *)
+      List.filter
+        (fun (name, _pkgs) ->
+          not
+            (List.exists
+               (fun (_,pks) ->
+                 List.exists (fun pk -> name = pk.package_name) pks)
+               missing))
+        missing
+    in
+    let cantbuild =
+      if missing = [] then cantbuild
+      else if missing_roots = [] then begin (* no roots ! *)
+        let rec find_cycle acc = function
+          | [] -> None
+          | name :: _ when List.mem name acc -> Some acc
+          | name :: r ->
+            let provides =
+              List.map (fun pk -> pk.package_name)
+                (try List.assoc name missing with Not_found -> [])
+            in
+            match find_cycle (name::acc) provides with
+            | Some _ as r -> r
+            | None -> find_cycle acc r
+        in
+        let cycle = List.map fst missing in
+        let cycle =
+          match find_cycle [] cycle with
+          | Some l -> l
+          | None -> assert false
+        in
+      (*TODO: these are only errors if the corresponding packages have
+        been specified as targets. *)
+        Printf.eprintf
+          "%sERROR%s: circular dependency between:\n"
+          term.esc_red_text term.esc_end;
+        List.iter
+          (fun (n1,n2) -> Printf.eprintf "  - %s%s%s depends on %s\n"
+            term.esc_bold n1 term.esc_end n2)
+          (List.combine cycle (List.tl cycle @ [List.hd cycle]));
+        cycle @ cantbuild
+      end else begin
+        Printf.eprintf
+          "%sERROR%s: the following packages are %smissing%s:\n"
+          term.esc_red_text term.esc_end  term.esc_bold term.esc_end;
+        List.iter (fun (name,_) ->
+          Printf.eprintf "  - %s%s%s\n" term.esc_bold name term.esc_end
+        ) missing_roots;
+        List.map fst missing_roots @ cantbuild
+      end
+    in
+    let cantbuild =
+      if pj.project_incomplete = [||] then cantbuild
+      else begin
+        let additional =
+          List.filter
+            (fun pk -> pk.package_source_kind <> "meta"
+              && not (List.mem pk.package_name cantbuild))
+            (Array.to_list pj.project_incomplete)
+        in
+        if additional <> [] then
+          Printf.eprintf
+            "Additional packages %s can't be built.\n"
+            (String.concat ", "
+               (List.map (fun pk -> Printf.sprintf "%s%s%s"
+                 term.esc_bold pk.package_name term.esc_end)
+                  additional));
+        List.map (fun pk -> pk.package_name) additional @ cantbuild
+      end
+    in
+  *)
+    cantbuild
+
+let print_build_context = ref false
+let do_init_project_building w p pj =
+  let build_dir_basename = !build_dir_basename_arg in
+
+  let build_dir_filename = (* absolute_filename *) build_dir_basename in
+
+  let build_dir_filename =
+    match !arch_arg with
+    | Arch host -> Filename.concat build_dir_filename host
+    | ArchNone -> build_dir_filename
+  in
+
+  BuildMisc.safe_mkdir build_dir_filename;
+
+  BuildActions.time_step "Saving raw project info...";
+  BuildOCP.save_project_state pj
+    (File.add_basename (File.of_string build_dir_filename) "ocp.ocpx");
+  BuildActions.time_step "   Done saving raw project info";
+
+  let b =
+    BuildEngineContext.create (File.to_string p.project_dir)
+      build_dir_filename in
+
+  begin match p.cout.cout_ocamlbin with
+  | None -> ()
+  | Some ocamlbin ->
+    ignore (BuildEngineContext.add_directory b ocamlbin);
+  end;
+
+  let bc = BuildGlobals.new_builder_context b in
+
+  let packages = BuildOCamlRules.create w p.cin p.cout bc pj in
+
+  if !print_build_context then
+    BuildEngineDisplay.eprint_context b;
+  (bc, packages)
+
+let load_initial_project pre_w p state =
+  let w = BuildWarnings.empty_set () in
+  do_load_project_files p.cin p.project_dir state;
+
+  (*    end; *)
+
+  (* [ocp-build configure] stops here, so it will not scan
+     for .ocp files at this point. Instead, it will be done the
+     first time the project is compiled, because [root_files] is
+     empty. *)
+
+  if !configure_arg then save_project := true;
+
+  (*
+  if !save_project then begin
+    Printf.fprintf stderr "Updating ocp-build.root\n%!";
+    BuildOptions.must_save_project ()
+  end;
+  *)
+
+  (*  if !conf_arg || !distrib_arg ||
+      !autogen_arg then BuildMisc.clean_exit 0; *)
+
+  let use_digests = p.cin.cin_digest in
+
+  if use_digests then BuildMtime.use_digests true;
+
+  BuildActions.time_step "Sorting packages...";
+  let pj = BuildOCP.verify_packages w state in
+
+  BuildActions.time_step "   Done sorting packages";
+
+  (*
+    do_reply_to_queries pj;
+  *)
+
+  if !query_global then begin
+    Printf.eprintf "Error: reached query-global end point.\n%!";
+    BuildMisc.clean_exit 0
+  end;
+
+  BuildOptions.maybe_save ();
+
+  if verbose 1 && term.esc_ansi then begin
+    let cantbuild = do_print_fancy_project_info pj in
+    if cantbuild <> [] then begin
+      BuildMisc.non_fatal_errors :=
+        "Some package dependencies are missing" :: !BuildMisc.non_fatal_errors
+    end
+  end
+  else
+    do_print_project_info pj;
+
+  let (bc, packages) = do_init_project_building w p pj in
+
+  let package_map =
+    let h = ref StringMap.empty in
+    Array.iter (fun p ->
+      let module P = (val p : Package) in
+      h := StringMap.add P.name p !h;
+    ) packages;
+    !h
+  in
+
+  BuildActionsWarnings.print_pj_warnings (BuildWarnings.diff w pre_w);
+
+  (bc, package_map)
+
+let load_installed_ocp = ref true
+let arg_ocp_dirs = ref []
+
+
+let do_read_env p =
+
+  let cin = p.cin in
+  let cout = p.cout in
+
+  BuildOCamlConfig.set_global_config cout;
+
+  (* Don't modify default values from now on, since they have been included
+     in the default configuration ! *)
+
+  let env_ocp_dirs = ref cin.cin_ocps_dirnames in
+  let env_ocp_files = ref [] in
+  let state = BuildOCP.init_packages () in
+
+  begin
+    match cout.cout_ocaml with
+    | None -> Printf.eprintf "Compiler: no ocaml detected\n%!"
+    | Some ocaml ->
+      Printf.eprintf "Compiler: ocaml %s\n%!" ocaml.ocaml_version
+  end;
+
+  begin
+    match cout.cout_ocamllib with
+    None -> ()
+    | Some ocamllib ->
+      if cin.cin_ocps_in_ocamllib then begin
+        env_ocp_dirs := ocamllib :: !env_ocp_dirs;
+      end;
+
+      BuildActions.time_step "Scanning env for .ocp files...";
+      if !load_installed_ocp then
+        List.iter (fun dir ->
+          if verbose 3 then
+            Printf.eprintf "Scanning installed .ocp files in %S\n%!" dir;
+          let dir = File.of_string dir in
+          env_ocp_files := ( BuildOCP.scan_root dir) @ !env_ocp_files
+        ) (!env_ocp_dirs @ cout.cout_meta_dirnames);
+        List.iter (fun dir ->
+          if verbose 3 then
+            Printf.eprintf "Scanning installed .ocp files in %S\n%!" dir;
+          let dir = File.of_string dir in
+          env_ocp_files := ( BuildOCP.scan_root dir) @ !env_ocp_files
+        ) !arg_ocp_dirs;
+      BuildActions.time_step "   Done scanning env for .ocp files";
+      BuildActions.time_step "Loading METAs...";
+      List.iter (fun dirname ->
+        BuildOCamlMeta.load_META_files state ocamllib dirname
+      ) cout.cout_meta_dirnames;
+  end;
+
+  BuildActions.time_step "   Done Loading METAs";
+
+  BuildActions.time_step "Loading .ocp files from env...";
+
+  let _nerrors1 =
+    let config = BuildOCP.generated_config () in
+    BuildOCP.load_ocp_files config state  !env_ocp_files
+  in
+
+  BuildActions.time_step "   Done Loading .ocp files from env";
+
+  state
+
+let chdir_to_project p =
+  let dir = File.to_string p.project_dir in
+  if MinUnix.getcwd () <> dir then begin
+    BuildMisc.chdir dir;
+    Printf.fprintf stdout "ocp-build: Entering directory `%s'\n%!"
+      (File.to_string p.project_dir);
+(* TODO: move at_exit to add_finally *)
+    let final_handler_executed = ref false in
+    let final_handler () =
+      if not !final_handler_executed then begin
+        final_handler_executed := true;
+        Printf.printf
+          "ocp-build: Leaving directory `%s'\n%!"
+          (File.to_string p.project_dir)
+      end
+    in
+    (*    add_finally final_handler; *)
+    at_exit final_handler
+  end;
+  ()
+
+let print_env_arg = ref false
+
+let init_env () =
+
+  let w = BuildWarnings.empty_set () in
+  let p = BuildActions.load_project w in
+  let env_state = do_read_env p in
+  let env_pj = BuildOCP.verify_packages w env_state in
+  if !print_env_arg then begin
+    BuildOCPPrinter.eprint_project "Environment packages" env_pj;
+    exit 0;
+  end;
+  BuildActions.time_step "Environment read and checked.";
+  (* TODO: we could check that all the packages are indeed installed ! *)
+
+  BuildOCamlVariables.packages_option.set
+    (VList (Array.to_list (Array.map (fun pk ->
+        let dirname = BuildGlobals.absolute_filename pk.package_dirname in
+        List.iter (fun suffix ->
+          BuildSubst.add_to_global_subst (pk.package_name ^ suffix) dirname)
+          [ "_SRC_DIR"; "_DST_DIR"; "_FULL_SRC_DIR"; "_FULL_DST_DIR" ];
+        VPair (VString pk.package_name, VObject pk.package_options)
+      ) env_pj.project_sorted)));
+
+  BuildActionsWarnings.print_env_warnings w;
+
+  (w, p, env_state, env_pj)
+
+let init_project env_w p env_state  =
+
+  chdir_to_project p;
+
+  let (bc, package_map) = load_initial_project env_w p
+    (BuildOCPInterp.copy_state env_state) in
+
+  (bc, package_map)
+
+
 let action () =
+  BuildActionsWarnings.set_default_is_always ();
+
   let root_dir = BuildOptions.project_build_dirname in
 
   if Sys.file_exists root_dir then begin
@@ -34,8 +523,25 @@ let action () =
     end;
     (* TODO: we should probably do some check to verify that we have
     write permission everywhere in _obuild. *)
-  end else
+  end else begin
     BuildMisc.safe_mkdir BuildOptions.project_build_dirname
+  end;
+  let (w, p, env_state, env_pj) = init_env () in
+  ignore (init_project w p env_state )
+
+let arg_list = [
+  "-I", Arg.String (fun dir ->
+    arg_ocp_dirs := !arg_ocp_dirs @ [ dir ]),
+  "DIR Include files from DIR";
+ "-print-loaded-env", Arg.Set
+    print_env_arg,
+  " Print the loaded environment and exit.";
+   "-no-installed-ocp", Arg.Clear load_installed_ocp,
+  " Do not load installed .ocp files";
+     "-print-build-context", Arg.Set print_build_context,
+  " Print full build context";
+] @
+  BuildActionsWarnings.arg_list
 
 let subcommand = {
   sub_name = "init";

--- a/tools/ocp-build/buildActionInit.mli
+++ b/tools/ocp-build/buildActionInit.mli
@@ -18,15 +18,28 @@
 (*  SOFTWARE.                                                             *)
 (**************************************************************************)
 
+val subcommand : BuildArgs.subcommand
+val action : unit -> unit
+val arg_list : (string * Arg.spec * string) list
 
-val plugin : (module BuildTypes.Plugin)
+val load_initial_project :
+  BuildActionsWarnings.set ->
+  BuildActions.project_info ->
+  BuildOCPInterp.state ->
+  BuildTypes.builder_context *
+    (module BuildTypes.Package) StringCompat.StringMap.t
 
-(* From the [validated_projects] table, fill the other
-   tables *)
-val create :
-  [> BuildOCamlSyntaxes.warning ] BuildWarnings.set ->
-  BuildOptions.config_input ->
-  BuildOCamlConfig.TYPES.config_output ->
-  BuildTypes.builder_context ->
-  BuildOCPTypes.project ->
-  (module BuildTypes.Package) array
+val init_env :
+  unit ->
+    BuildActionsWarnings.set *
+    BuildActions.project_info * BuildOCPInterp.state *
+    BuildOCPTypes.project
+
+val init_project :
+  BuildActionsWarnings.set ->
+  BuildActions.project_info ->
+  BuildOCPInterp.state ->
+  BuildTypes.builder_context *
+    (module BuildTypes.Package) StringCompat.StringMap.t
+
+val chdir_to_project : BuildActions.project_info -> unit

--- a/tools/ocp-build/buildActionInstall.ml
+++ b/tools/ocp-build/buildActionInstall.ml
@@ -140,8 +140,7 @@ let arg_list =
 
 let action () =
   BuildActionBuild.make_build_targets := true;
-  let p = BuildActions.load_project () in
-  let (bc, projects,package_map) = BuildActionBuild.do_build p in
+  let (p, bc, projects,package_map) = BuildActionBuild.do_build () in
 
   let install_where = BuildOCamlInstall.install_where p.cin p.cout in
   let install_what = BuildOCamlInstall.install_what () in

--- a/tools/ocp-build/buildActionQuery.ml
+++ b/tools/ocp-build/buildActionQuery.ml
@@ -115,6 +115,11 @@ let do_list_packages pj =
     Printf.printf "\n";
   ) (List.sort (fun pk1 pk2 -> compare pk1.package_name pk2.package_name)
       (Array.to_list pj.project_sorted));
+  Printf.printf "DISABLED:\n%!";
+  Array.iter (fun pk ->
+    Printf.printf "  %s (in %s)\n" pk.package_name pk.package_dirname
+  ) pj.project_disabled;
+  (*
   Printf.printf "MISSING:\n%!";
   List.iter (fun (package_name, missed_by) ->
     Printf.printf "  %s missed by:\n" package_name;
@@ -122,28 +127,19 @@ let do_list_packages pj =
       Printf.printf "    %s (in %s)\n" pk.package_name pk.package_dirname
     ) missed_by;
   ) pj.project_missing;
-  Printf.printf "DISABLED:\n%!";
-  Array.iter (fun pk ->
-    Printf.printf "  %s (in %s)\n" pk.package_name pk.package_dirname
-  ) pj.project_disabled;
   Printf.printf "INCOMPLETE:\n%!";
   Array.iter (fun pk ->
     Printf.printf "  %s (in %s)\n" pk.package_name pk.package_dirname
   ) pj.project_incomplete;
+  *)
   ()
 
 let action () =
-  let p = BuildActions.load_project () in
-  let state = BuildActionBuild.do_read_env p in
+  let (_env_w, p, state, pj) = BuildActionInit.init_env () in
 
-    time_step "Sorting packages...";
-    let pj = BuildOCP.verify_packages state in
-
-    time_step "   Done sorting packages";
-
-    if !list_arg then
-      do_list_packages pj
-    else
+  if !list_arg then
+    do_list_packages pj
+  else
     do_reply_to_queries pj;
 
   ()

--- a/tools/ocp-build/buildActionTests.ml
+++ b/tools/ocp-build/buildActionTests.ml
@@ -61,8 +61,8 @@ let action () =
     if !make_doc_targets then make_build_targets := true;
   );
 
-  let p = BuildActions.load_project () in
-  let (bc, projects, _package_map) = BuildActionBuild.do_build p in
+
+  let (p, bc, projects, _package_map) = BuildActionBuild.do_build () in
   do_test bc.build_context (BuildActionBuild.get_ncores p.cin) projects;
   ()
 

--- a/tools/ocp-build/buildActions.ml
+++ b/tools/ocp-build/buildActions.ml
@@ -133,7 +133,7 @@ type project_info = {
   cout : BuildOCamlConfig.TYPES.config_output;
 }
 
-let load_project () =
+let load_project w =
   let project_dir = BuildOptions.find_project_root () in
 
   time_step "Loading configuration files...";
@@ -147,7 +147,7 @@ let load_project () =
       OnlyUnix.isatty MinUnix.stdout && OnlyUnix.isatty MinUnix.stderr)));
 
   time_step "Checking OCaml config...";
-  let cout = BuildOCamlConfig.check_config cin in
+  let cout = BuildOCamlConfig.check_config w cin in
   time_step "   Done checking OCaml config.";
 
 

--- a/tools/ocp-build/buildActions.mli
+++ b/tools/ocp-build/buildActions.mli
@@ -33,4 +33,5 @@ type project_info = {
 }
 
 
-val load_project : unit -> project_info
+val load_project :
+  [> `MissingTool of string ] BuildWarnings.set -> project_info

--- a/tools/ocp-build/buildActionsWarnings.ml
+++ b/tools/ocp-build/buildActionsWarnings.ml
@@ -41,7 +41,7 @@ let env_warnings_kind = "env"
 let pj_warnings_kind = "project"
 
 let arg_no_warnings_string = "--no-warnings"
-let arg_warnings_fmt = ("--%s-warnings" :  ('a -> 'b, unit, string) format)
+let arg_warnings_fmt = ("--%s-warnings" :  _ format)
 let arg_pj_warnings_string = Printf.sprintf arg_warnings_fmt pj_warnings_kind
 let arg_env_warnings_string = Printf.sprintf arg_warnings_fmt env_warnings_kind
 let arg_all_warnings_string = "--all-warnings"

--- a/tools/ocp-build/buildActionsWarnings.ml
+++ b/tools/ocp-build/buildActionsWarnings.ml
@@ -41,12 +41,12 @@ let env_warnings_kind = "env"
 let pj_warnings_kind = "project"
 
 let arg_no_warnings_string = "--no-warnings"
-let arg_warnings_fmt = ("--%s-warnings" :  _ format)
+let arg_warnings_fmt = format_of_string "--%s-warnings"
 let arg_pj_warnings_string = Printf.sprintf arg_warnings_fmt pj_warnings_kind
 let arg_env_warnings_string = Printf.sprintf arg_warnings_fmt env_warnings_kind
 let arg_all_warnings_string = "--all-warnings"
 
-let warnings_filename_fmt = ("_obuild/%s_warnings.data" : _ format)
+let warnings_filename_fmt = format_of_string "_obuild/%s_warnings.data"
 
 let arg_print_env_warnings = ref PrintWarningsIfChanged
 let arg_print_pj_warnings = ref PrintWarningsIfChanged

--- a/tools/ocp-build/buildActionsWarnings.ml
+++ b/tools/ocp-build/buildActionsWarnings.ml
@@ -1,0 +1,168 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlPro TypeRex                          *)
+(*                                                                        *)
+(*   Copyright OCamlPro 2011-2016. All rights reserved.                   *)
+(*   This file is distributed under the terms of the GPL v3.0             *)
+(*      (GNU Public Licence version 3.0).                                 *)
+(*                                                                        *)
+(*     Contact: <typerex@ocamlpro.com> (http://www.ocamlpro.com/)         *)
+(*                                                                        *)
+(*  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       *)
+(*  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES       *)
+(*  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND              *)
+(*  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS   *)
+(*  BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN    *)
+(*  ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN     *)
+(*  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE      *)
+(*  SOFTWARE.                                                             *)
+(**************************************************************************)
+
+open StringCompat
+open BuildOCPTypes
+
+type warning =
+[
+  BuildOCP.warning
+| BuildOCamlConfig.warning
+| BuildOCamlSyntaxes.warning
+]
+
+type set = warning BuildWarnings.set
+
+type print_warnings =
+| PrintWarningsAlways
+| PrintWarningsIfChanged
+| PrintWarningsNever
+
+let warnings_version = 1
+
+let env_warnings_kind = "env"
+let pj_warnings_kind = "project"
+
+let arg_no_warnings_string = "--no-warnings"
+let arg_warnings_fmt = ("--%s-warnings" :  ('a -> 'b, unit, string) format)
+let arg_pj_warnings_string = Printf.sprintf arg_warnings_fmt pj_warnings_kind
+let arg_env_warnings_string = Printf.sprintf arg_warnings_fmt env_warnings_kind
+let arg_all_warnings_string = "--all-warnings"
+
+let warnings_filename_fmt = ("_obuild/%s_warnings.data" : _ format)
+
+let arg_print_env_warnings = ref PrintWarningsIfChanged
+let arg_print_pj_warnings = ref PrintWarningsIfChanged
+
+let arg_list = [
+  arg_no_warnings_string, Arg.Unit (fun () ->
+    arg_print_pj_warnings := PrintWarningsNever;
+    arg_print_env_warnings := PrintWarningsNever;
+  ),
+  " Print no warnings at all";
+  arg_all_warnings_string, Arg.Unit (fun () ->
+    arg_print_env_warnings := PrintWarningsAlways;
+    arg_print_pj_warnings := PrintWarningsAlways;
+  ),
+  " Print all warnings, even if no changed";
+  arg_env_warnings_string, Arg.Unit (fun () ->
+    arg_print_env_warnings := PrintWarningsAlways;
+  ),
+  " Print env warnings, even if no changed";
+  arg_pj_warnings_string, Arg.Unit (fun () ->
+    arg_print_pj_warnings := PrintWarningsAlways;
+  ),
+  " Print project warnings, even if no changed";
+
+]
+
+let print_warning (w : warning) =
+  match w with
+  | `MissingDirectory (dirname, name, filename) ->
+    Printf.eprintf
+      "Warning: directory %S for package does not exist: \
+            \   Package %S in %S disabled.\n%!"
+      dirname name filename
+  | `MissingTool tool ->
+    Printf.eprintf "Warning: Could not find OCaml %s tool.\n" tool
+  | `PackageConflict (pk1, pk2, pk3) ->
+    BuildOCP.print_conflict pk1 pk2 pk3
+  | `BadInstalledPackage (name1, name2) ->
+    Printf.eprintf
+      "Warning: installed package %s depends on source package %s\n%!"
+      name1 name2
+  | `MissingDependency (kind, name, dep) ->
+      Printf.eprintf "Warning: missing dependency, %s %S requires %S\n%!"
+        kind name dep
+  | `KindMismatch (kind, name, kind2, name2) ->
+    Printf.eprintf
+      "Warning: %s %S depends on %S, that only exists in %s\n%!"
+      kind name name2 kind2
+  | `SyntaxDepDeclaredAsNotSyntax (lib_name, tool_name, pk_name) ->
+    Printf.eprintf "Warning: in package %S, %s_requires: dependency %S not declared as syntax" lib_name tool_name pk_name
+  | `SyntaxDepNotDeclared (lib_name, tool_name, pk_name) ->
+    Printf.fprintf stderr "Warning: in package %s, %s_requires dependency %S not declared\n%!"
+      lib_name tool_name pk_name
+  | `IncompletePackage pk ->
+    Printf.eprintf "Warning: package %S disabled\n" pk.package_name
+  | `MissingPackage (name, pks) ->
+    Printf.eprintf "Warning: missing package %S, needed by\n" name;
+    List.iter (fun pk ->
+      Printf.eprintf "  * %S\n%!" pk.package_name) pks
+
+
+let print_warnings arg_print_warnings warnings_kind w =
+  let warnings_filename = Printf.sprintf warnings_filename_fmt warnings_kind in
+  let count = BuildWarnings.count w in
+  if count = 0 then begin
+    (try Sys.remove warnings_filename with _ -> ());
+  end else begin
+    if
+        match arg_print_warnings with
+      | PrintWarningsNever ->
+        BuildWarnings.clear w;
+        Printf.eprintf
+          "Warning: %d %s warnings were not printed (remove %s)\n%!"
+          count warnings_kind arg_no_warnings_string;
+        false
+
+      | PrintWarningsIfChanged ->
+        let old_w =
+          try
+            let ic = open_in_bin warnings_filename in
+            let (version : int) = input_value ic in
+            if version <> warnings_version then raise Exit;
+            let (w : 'a BuildWarnings.set) = input_value ic in
+            close_in ic;
+            w
+          with _ ->
+            BuildWarnings.empty_set ()
+        in
+        let equal = BuildWarnings.equal w old_w in
+        if equal then begin
+          Printf.eprintf
+            "Warning: %d old %s warnings were not printed (add %(%s%))\n%!"
+            count warnings_kind arg_warnings_fmt warnings_kind
+        end;
+        not equal
+      | PrintWarningsAlways -> true
+
+        then begin
+          Printf.eprintf "----- %d %s warnings -----\n" count warnings_kind;
+          BuildWarnings.iter print_warning w
+        end;
+        let oc = open_out_bin warnings_filename in
+        output_value oc warnings_version;
+        output_value oc w;
+        close_out oc
+    end
+
+let set_default_is_always () =
+  if !arg_print_env_warnings = PrintWarningsIfChanged then
+    arg_print_env_warnings := PrintWarningsAlways;
+  if !arg_print_pj_warnings = PrintWarningsIfChanged then
+    arg_print_pj_warnings := PrintWarningsAlways;
+  ()
+
+let print_env_warnings w =
+  print_warnings !arg_print_env_warnings env_warnings_kind w
+
+let print_pj_warnings w =
+  print_warnings !arg_print_pj_warnings pj_warnings_kind  w

--- a/tools/ocp-build/buildActionsWarnings.mli
+++ b/tools/ocp-build/buildActionsWarnings.mli
@@ -18,15 +18,22 @@
 (*  SOFTWARE.                                                             *)
 (**************************************************************************)
 
+val arg_list : (string * Arg.spec * string) list
 
-val plugin : (module BuildTypes.Plugin)
+type warning =
+[
+| BuildOCP.warning
+| BuildOCamlConfig.warning
+| BuildOCamlSyntaxes.warning
+]
 
-(* From the [validated_projects] table, fill the other
-   tables *)
-val create :
-  [> BuildOCamlSyntaxes.warning ] BuildWarnings.set ->
-  BuildOptions.config_input ->
-  BuildOCamlConfig.TYPES.config_output ->
-  BuildTypes.builder_context ->
-  BuildOCPTypes.project ->
-  (module BuildTypes.Package) array
+type set = warning BuildWarnings.set
+
+val set_default_is_always : unit -> unit
+
+(* [print_env_warnings set] prints warnings from [set],
+   using [filename] as a reminder of former warnings, and update
+   [filename] consequently. [kind] is a simple string to characterize
+   these warnings, typically "env" or "project" *)
+val print_env_warnings : set -> unit
+val print_pj_warnings : set -> unit

--- a/tools/ocp-build/buildMain.ml
+++ b/tools/ocp-build/buildMain.ml
@@ -43,7 +43,7 @@ let _ = DebugVerbosity.add_submodules "B" [ "BuildMain" ]
 
 
 let finally () =
-  List.iter (fun action -> action ()) !BuildActionBuild.finally_do;
+  (*  List.iter (fun action -> action ()) !BuildActionBuild.finally_do; *)
   time_step "End of execution";
 
   if !time_arg then begin
@@ -128,7 +128,6 @@ let _ =
     BuildMisc.clean_exit 0
   with
   | BuildMisc.ExitStatus n ->
-    finally ();
     let exit_status =
       if n = 0 then
         match !BuildMisc.non_fatal_errors with

--- a/tools/ocp-build/buildOCP.mli
+++ b/tools/ocp-build/buildOCP.mli
@@ -23,6 +23,18 @@
 (* open BuildBase *)
 open BuildOCPTypes
 
+type warning =
+[ `MissingDirectory of string * string * string
+| `PackageConflict of
+    BuildOCPTypes.final_package * BuildOCPTypes.final_package *
+      BuildOCPTypes.final_package
+| `BadInstalledPackage of string * string
+| `MissingDependency of string * string * string
+| `KindMismatch of string * string * string * string
+| `IncompletePackage of BuildOCPTypes.final_package
+| `MissingPackage of string * BuildOCPTypes.final_package list
+]
+
 val print_loaded_ocp_files : bool ref
 val print_package_deps : bool ref
 val print_missing_deps : bool ref
@@ -31,7 +43,11 @@ val init_packages : unit -> BuildOCPInterp.state
 val load_ocp_files :
   BuildOCPInterp.config ->
   BuildOCPInterp.state -> File.t list -> int
-val verify_packages : BuildOCPInterp.state -> BuildOCPTypes.project
+
+val verify_packages :
+  [> warning ] BuildWarnings.set ->
+  BuildOCPInterp.state ->
+  BuildOCPTypes.project
 
 (* val load_project : File.t list -> project * int *)
 
@@ -40,7 +56,7 @@ val verify_packages : BuildOCPInterp.state -> BuildOCPTypes.project
 val find_root : File.t -> string list -> File.t
 
 (*
-val save_project : File.t -> project -> unit
+  val save_project : File.t -> project -> unit
 *)
 
 val scan_root : File.t -> File.t list
@@ -60,6 +76,9 @@ val find_obuild : (string -> unit) -> string -> unit
 val empty_config : unit -> BuildOCPInterp.config
 val generated_config : unit -> BuildOCPInterp.config
 
-val print_conflicts : project -> bool -> unit
+val print_conflict :
+  'a BuildOCPTypes.package ->
+  'b BuildOCPTypes.package ->
+  'c BuildOCPTypes.package -> unit
 
 (* val eprint_project : string -> project -> unit *)

--- a/tools/ocp-build/buildOCPInterp.ml
+++ b/tools/ocp-build/buildOCPInterp.ml
@@ -169,18 +169,20 @@ let add_project_dep pk s options =
  for which we should use another loading phase.
 *)
 
-let check_package pk =
+let check_package w pk =
   let options = pk.package_options in
 
     if BuildValue.get_bool_with_default [options] "enabled" true &&
        not ( BuildMisc.exists_as_directory pk.package_dirname ) then begin
       (* TODO: we should probably do much more than that, i.e. disable also a
          package when some files are missing. *)
-      Printf.eprintf "Warning: directory %S for package does not exist:\n"
-        pk.package_dirname;
-      Printf.eprintf "  Package %S in %S disabled.\n%!"
-        pk.package_name pk.package_filename;
-      pk.package_options <- BuildValue.set_bool options "enabled" false;
+         BuildWarnings.add w
+           (`MissingDirectory
+               (
+                 pk.package_dirname,
+                 pk.package_name,
+                 pk.package_filename));
+         pk.package_options <- BuildValue.set_bool options "enabled" false;
     end else begin
 
       pk.package_version <- BuildValue.get_string_with_default [pk.package_options]

--- a/tools/ocp-build/buildOCPInterp.mli
+++ b/tools/ocp-build/buildOCPInterp.mli
@@ -88,7 +88,9 @@ val new_package_dep :
 
 val read_ocamlconf :  state -> config -> string -> config
 
-val check_package : final_package -> unit
+val check_package :
+  [> `MissingDirectory of string * string * string ] BuildWarnings.set
+  -> final_package -> unit
 
 type prim
 

--- a/tools/ocp-build/buildOCPPrinter.ml
+++ b/tools/ocp-build/buildOCPPrinter.ml
@@ -215,18 +215,17 @@ let package_x_package_x_package b indent (p1,p2,p3) =
   package_uid b indent p3
 
 let project b indent p =
-  let indent2 = indent ^ "  " in
   Printf.bprintf b "{\n";
+  Printf.bprintf b ";\n%s  project_sorted = " indent;
+  array_of final_package b indent p.project_sorted;
+  (*
   Printf.bprintf b "%s  project_disabled = " indent;
   array_of final_package b indent p.project_disabled;
   Printf.bprintf b ";\n%s  project_incomplete = " indent;
   array_of final_package b indent p.project_incomplete;
-  Printf.bprintf b ";\n%s  project_sorted = " indent;
-  array_of final_package b indent p.project_sorted;
   Printf.bprintf b ";\n%s  project_missing = " indent;
   list_of string_x_package_list b indent p.project_missing;
-  Printf.bprintf b ";\n%s  project_conflicts = " indent;
-  list_of package_x_package_x_package b indent2 p.project_conflicts;
+  *)
   Printf.bprintf b " }\n"
 
 let string_of_project p =

--- a/tools/ocp-build/buildOCPTypes.ml
+++ b/tools/ocp-build/buildOCPTypes.ml
@@ -86,9 +86,10 @@ and 'a package_dependency =
     }
 
 and project = {
-  mutable project_disabled : final_package array;
-  mutable project_incomplete : final_package array;
   mutable project_sorted : final_package array;
+  mutable project_disabled : final_package array;
+  (*
+  mutable project_incomplete : final_package array;
   mutable project_missing : (string * final_package list) list;
-  mutable project_conflicts :  (final_package * final_package *  final_package) list;
+  *)
 }

--- a/tools/ocp-build/buildOCPTypes.mli
+++ b/tools/ocp-build/buildOCPTypes.mli
@@ -86,9 +86,10 @@ and 'a package_dependency =
     }
 
 and project = {
-  mutable project_disabled : final_package array;
-  mutable project_incomplete : final_package array;
   mutable project_sorted : final_package array;
+  mutable project_disabled : final_package array;
+  (*
+  mutable project_incomplete : final_package array;
   mutable project_missing : (string * final_package list) list;
-  mutable project_conflicts :  (final_package * final_package *  final_package) list;
+  *)
 }

--- a/tools/ocp-build/buildOCamlConfig.ml
+++ b/tools/ocp-build/buildOCamlConfig.ml
@@ -31,6 +31,10 @@ open BuildValue.Types
 open BuildConfig
 open BuildOptions
 
+type warning = [
+| `MissingTool of string
+]
+
 module TYPES = struct
 
   type ocaml_config = {
@@ -162,7 +166,7 @@ let check_is_ocamlyacc = check_is_compiler ',' ocamlyacc_prefixes [ "-version" ]
 let check_is_ocamlmklib = check_is_compiler ',' ocamlmklib_prefixes [ "-version" ]
 
 
-let check_config cin =
+let check_config w cin =
 
   let cout = {
     cout_ocamlc = None;
@@ -290,8 +294,8 @@ let check_config cin =
   let ocamldoc = find_first_in_path path check_is_ocamldoc
       [ "ocamldoc" ] in
   begin match ocamldoc with
-      None ->
-      Printf.eprintf "Warning: Could not find OCaml ocamldoc tool.\n";
+    None ->
+      BuildWarnings.add w (`MissingTool "ocamldoc");
       cout.cout_ocamldoc <- Some [ "no-ocamldoc-detected" ]
     | Some ocamldoc ->
       cout.cout_ocamldoc <- Some [ocamldoc];

--- a/tools/ocp-build/buildOCamlConfig.mli
+++ b/tools/ocp-build/buildOCamlConfig.mli
@@ -96,5 +96,11 @@ val arg_list : unit -> (string * Arg.spec * string) list
 val load_global_config : File.t -> unit
 *)
 
-val check_config : BuildOptions.config_input -> config_output
+type warning = [
+| `MissingTool of string
+]
+
+val check_config :
+  [> warning ] BuildWarnings.set ->
+  BuildOptions.config_input -> config_output
 val set_global_config : config_output -> unit

--- a/tools/ocp-build/buildOCamlSyntaxes.mli
+++ b/tools/ocp-build/buildOCamlSyntaxes.mli
@@ -18,8 +18,13 @@
 (*  SOFTWARE.                                                             *)
 (**************************************************************************)
 
+type warning = [
+| `SyntaxDepDeclaredAsNotSyntax of string * string * string
+| `SyntaxDepNotDeclared of string * string * string
+]
 
 val get_pp :
+  [> warning ] BuildWarnings.set ->
   BuildOCamlTypes.ocaml_package ->
   string -> (* source basename *)
   BuildValue.Types.env ->
@@ -31,6 +36,7 @@ val add_pp_requires :
   BuildEngineTypes.build_rule -> BuildOCamlTypes.pp -> unit
 
 val get_tool_requires :
+  [> warning ] BuildWarnings.set ->
   string ->
   BuildOCamlTypes.ocaml_package ->
   string list ->

--- a/tools/ocp-build/buildOptions.ml
+++ b/tools/ocp-build/buildOptions.ml
@@ -987,7 +987,6 @@ let rec shortcut_arg new_name old_name list =
       else shortcut_arg new_name old_name list
 
 let find_project_root () =
-  Printf.eprintf "find_project_root\n%!";
   try
     BuildOCP.find_root (File.getcwd()) [ project_build_dirname ]
   with  Not_found ->

--- a/tools/ocp-build/buildWarnings.ml
+++ b/tools/ocp-build/buildWarnings.ml
@@ -18,15 +18,47 @@
 (*  SOFTWARE.                                                             *)
 (**************************************************************************)
 
+(* Find an interface to deal with different severity of warnings.
+For example, [equal] does only compare the [warnings] field,  so if
+we create another field, equal will still not change.
+*)
 
-val plugin : (module BuildTypes.Plugin)
+open StringCompat
 
-(* From the [validated_projects] table, fill the other
-   tables *)
-val create :
-  [> BuildOCamlSyntaxes.warning ] BuildWarnings.set ->
-  BuildOptions.config_input ->
-  BuildOCamlConfig.TYPES.config_output ->
-  BuildTypes.builder_context ->
-  BuildOCPTypes.project ->
-  (module BuildTypes.Package) array
+type 'a set = {
+  mutable warnings : 'a list;
+  mutable count : int; (* length of [warnings] field *)
+  mutable sorted : bool;
+}
+
+let empty_set () = { warnings = []; count = 0; sorted = true; }
+let add w e =
+  w.warnings <- e :: w.warnings;
+  w.count <- w.count + 1;
+  w.sorted <- false
+
+let iter f w =
+  List.iter f (List.rev w.warnings)
+let count w = w.count
+let sort w =
+  if not w.sorted then begin
+    w.warnings <- List.sort compare w.warnings;
+    w.sorted <- true
+  end
+let equal w1 w2 =
+  w1.count = w2.count && (sort w1; sort w2; w1.warnings = w2.warnings)
+let copy w = { w with count = w.count }
+let clear w =
+  w.sorted <- true;
+  w.count <- 0;
+  w.warnings <- []
+
+let diff w1 w2 =
+  if w2.count = 0 then w1 else
+    let w = empty_set () in
+    let pre = Hashtbl.create 111 in
+    List.iter (fun ww -> Hashtbl.add pre ww ()) w2.warnings;
+    List.iter (fun ww ->
+      if not (Hashtbl.mem pre ww) then add w ww
+    ) w1.warnings;
+    w

--- a/tools/ocp-build/buildWarnings.mli
+++ b/tools/ocp-build/buildWarnings.mli
@@ -18,15 +18,14 @@
 (*  SOFTWARE.                                                             *)
 (**************************************************************************)
 
+type 'a set
 
-val plugin : (module BuildTypes.Plugin)
-
-(* From the [validated_projects] table, fill the other
-   tables *)
-val create :
-  [> BuildOCamlSyntaxes.warning ] BuildWarnings.set ->
-  BuildOptions.config_input ->
-  BuildOCamlConfig.TYPES.config_output ->
-  BuildTypes.builder_context ->
-  BuildOCPTypes.project ->
-  (module BuildTypes.Package) array
+val empty_set : unit -> 'a set
+val add : 'a set -> 'a -> unit
+val iter : ('a -> unit) -> 'a set -> unit
+val count : 'a set -> int
+val sort : 'a set -> unit
+val equal : 'a set -> 'a set -> bool
+val copy : 'a set -> 'a set
+val clear : 'a set -> unit
+val diff : 'a set -> 'a set -> 'a set

--- a/tools/ocp-build/projectMain.ml
+++ b/tools/ocp-build/projectMain.ml
@@ -96,7 +96,8 @@ let _ =
   let state = BuildOCP.init_packages () in
   let config = BuildOCP.empty_config () in
   let nerrors = BuildOCP.load_ocp_files config state files in
-  let pj = BuildOCP.verify_packages state in
+  let w = BuildWarnings.empty_set () in
+  let pj = BuildOCP.verify_packages w state in
   if nerrors > 0 then exit 2;
   print_dependencies pj packages;
   ()


### PR DESCRIPTION
Warnings are always printed with "ocp-build init", but only when needed with
"ocp-build build"
