### PR TITLE
Add support for aliases

### DIFF
--- a/.depend
+++ b/.depend
@@ -58,13 +58,11 @@ libs/ocplib-file/fileDir.cmi : \
 libs/ocplib-file/fileGen.cmo : libs/ocplib-lang/ocpString.cmi \
     libs/ocplib-compat/string-compat/ocpCompat.cmo \
     libs/ocplib-maxunix/minUnix.cmo libs/ocplib-file/fileString.cmi \
-    libs/ocplib-file/fileOS.cmi libs/ocplib-file/fileLines.cmi \
-    libs/ocplib-file/fileChannel.cmi libs/ocplib-file/fileGen.cmi
+    libs/ocplib-file/fileOS.cmi libs/ocplib-file/fileGen.cmi
 libs/ocplib-file/fileGen.cmx : libs/ocplib-lang/ocpString.cmx \
     libs/ocplib-compat/string-compat/ocpCompat.cmx \
     libs/ocplib-maxunix/minUnix.cmx libs/ocplib-file/fileString.cmx \
-    libs/ocplib-file/fileOS.cmx libs/ocplib-file/fileLines.cmx \
-    libs/ocplib-file/fileChannel.cmx libs/ocplib-file/fileGen.cmi
+    libs/ocplib-file/fileOS.cmx libs/ocplib-file/fileGen.cmi
 libs/ocplib-file/fileGen.cmi : \
     libs/ocplib-compat/string-compat/ocpCompat.cmo \
     libs/ocplib-file/fileSig.cmo
@@ -396,6 +394,19 @@ tools/ocp-build/buildConfig.cmx : libs/ocplib-lang/ocpString.cmx \
     libs/ocplib-maxunix/minUnix.cmx libs/ocplib-file/fileString.cmx \
     tools/ocp-build/buildConfig.cmi
 tools/ocp-build/buildConfig.cmi :
+tools/ocp-build/buildDepMisc.cmo : libs/ocplib-debug/ocpDebug.cmi \
+    libs/ocplib-compat/string-compat/ocpCompat.cmo \
+    tools/ocp-build/buildValue.cmi tools/ocp-build/buildTypes.cmi \
+    tools/ocp-build/buildOCPTypes.cmi \
+    tools/ocp-build/engine/buildEngineTypes.cmi \
+    tools/ocp-build/buildDepMisc.cmi
+tools/ocp-build/buildDepMisc.cmx : libs/ocplib-debug/ocpDebug.cmx \
+    libs/ocplib-compat/string-compat/ocpCompat.cmx \
+    tools/ocp-build/buildValue.cmx tools/ocp-build/buildTypes.cmx \
+    tools/ocp-build/buildOCPTypes.cmx \
+    tools/ocp-build/engine/buildEngineTypes.cmx \
+    tools/ocp-build/buildDepMisc.cmi
+tools/ocp-build/buildDepMisc.cmi :
 tools/ocp-build/buildGlobals.cmo : libs/ocplib-lang/ocpDigest.cmi \
     libs/ocplib-debug/ocpDebug.cmi \
     libs/ocplib-compat/string-compat/ocpCompat.cmo \
@@ -747,12 +758,10 @@ tools/ocp-build/lang-ocp2/buildOCP2Lexer.cmx : \
     tools/ocp-build/lang-ocp2/buildOCP2Lexer.cmi
 tools/ocp-build/lang-ocp2/buildOCP2Lexer.cmi :
 tools/ocp-build/lang-ocp2/buildOCP2Parse.cmo : \
-    libs/ocplib-lang/ocamllexer.cmi \
     tools/ocp-build/lang-ocp2/buildOCP2Parser.cmi \
     tools/ocp-build/lang-ocp2/buildOCP2Lexer.cmi \
     tools/ocp-build/misc/buildMisc.cmo
 tools/ocp-build/lang-ocp2/buildOCP2Parse.cmx : \
-    libs/ocplib-lang/ocamllexer.cmx \
     tools/ocp-build/lang-ocp2/buildOCP2Parser.cmx \
     tools/ocp-build/lang-ocp2/buildOCP2Lexer.cmx \
     tools/ocp-build/misc/buildMisc.cmx
@@ -808,12 +817,10 @@ tools/ocp-build/meta/metaLexer.cmo : tools/ocp-build/meta/metaLexer.cmi
 tools/ocp-build/meta/metaLexer.cmx : tools/ocp-build/meta/metaLexer.cmi
 tools/ocp-build/meta/metaLexer.cmi :
 tools/ocp-build/meta/metaParser.cmo : libs/ocplib-lang/ocpString.cmi \
-    libs/ocplib-debug/ocpDebug.cmi \
     libs/ocplib-compat/string-compat/ocpCompat.cmo \
     tools/ocp-build/meta/metaTypes.cmo tools/ocp-build/meta/metaLexer.cmi \
     tools/ocp-build/meta/metaParser.cmi
 tools/ocp-build/meta/metaParser.cmx : libs/ocplib-lang/ocpString.cmx \
-    libs/ocplib-debug/ocpDebug.cmx \
     libs/ocplib-compat/string-compat/ocpCompat.cmx \
     tools/ocp-build/meta/metaTypes.cmx tools/ocp-build/meta/metaLexer.cmx \
     tools/ocp-build/meta/metaParser.cmi
@@ -1038,6 +1045,7 @@ tools/ocp-build/ocaml/buildOCamlRules.cmo : libs/ocplib-lang/ocpToposort.cmi \
     tools/ocp-build/engine/buildEngineGlobals.cmi \
     tools/ocp-build/engine/buildEngineDisplay.cmi \
     tools/ocp-build/engine/buildEngineContext.cmi \
+    tools/ocp-build/buildDepMisc.cmi \
     tools/ocp-build/ocaml/buildOCamlRules.cmi
 tools/ocp-build/ocaml/buildOCamlRules.cmx : libs/ocplib-lang/ocpToposort.cmx \
     libs/ocplib-lang/ocpSubst.cmx libs/ocplib-lang/ocpString.cmx \
@@ -1063,6 +1071,7 @@ tools/ocp-build/ocaml/buildOCamlRules.cmx : libs/ocplib-lang/ocpToposort.cmx \
     tools/ocp-build/engine/buildEngineGlobals.cmx \
     tools/ocp-build/engine/buildEngineDisplay.cmx \
     tools/ocp-build/engine/buildEngineContext.cmx \
+    tools/ocp-build/buildDepMisc.cmx \
     tools/ocp-build/ocaml/buildOCamlRules.cmi
 tools/ocp-build/ocaml/buildOCamlRules.cmi : \
     tools/ocp-build/misc/buildWarnings.cmi tools/ocp-build/buildTypes.cmi \
@@ -1174,7 +1183,7 @@ tools/ocp-build/ocaml/buildOCamldep.cmo : libs/ocplib-lang/ocpString.cmi \
     tools/ocp-build/ocaml/buildOCamlTypes.cmi \
     tools/ocp-build/buildOCPTypes.cmi \
     tools/ocp-build/engine/buildEngineTypes.cmi \
-    tools/ocp-build/ocaml/buildOCamldep.cmi
+    tools/ocp-build/buildDepMisc.cmi tools/ocp-build/ocaml/buildOCamldep.cmi
 tools/ocp-build/ocaml/buildOCamldep.cmx : libs/ocplib-lang/ocpString.cmx \
     libs/ocplib-debug/ocpDebug.cmx \
     libs/ocplib-compat/string-compat/ocpCompat.cmx \
@@ -1183,7 +1192,7 @@ tools/ocp-build/ocaml/buildOCamldep.cmx : libs/ocplib-lang/ocpString.cmx \
     tools/ocp-build/ocaml/buildOCamlTypes.cmx \
     tools/ocp-build/buildOCPTypes.cmx \
     tools/ocp-build/engine/buildEngineTypes.cmx \
-    tools/ocp-build/ocaml/buildOCamldep.cmi
+    tools/ocp-build/buildDepMisc.cmx tools/ocp-build/ocaml/buildOCamldep.cmi
 tools/ocp-build/ocaml/buildOCamldep.cmi : tools/ocp-build/buildValue.cmi \
     tools/ocp-build/ocaml/buildOCamlTypes.cmi \
     tools/ocp-build/engine/buildEngineTypes.cmi

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,8 @@ BUILD_LIB= $(OCP_BUILD_SRCDIR)/buildVersion.ml	\
     $(OCP_BUILD_SRCDIR)/buildOptions.ml		\
     $(OCP_BUILD_SRCDIR)/buildGlobals.ml		\
     $(OCP_BUILD_SRCDIR)/buildConfig.ml		\
-    $(OCP_BUILD_SRCDIR)/buildUninstall.ml		
+    $(OCP_BUILD_SRCDIR)/buildUninstall.ml	\
+    $(OCP_BUILD_SRCDIR)/buildDepMisc.ml
 
 BUILD_OCAMLFIND= $(OCP_BUILD_SRCDIR)/meta/metaTypes.ml	\
     $(OCP_BUILD_SRCDIR)/meta/metaLexer.ml		\

--- a/tools/ocp-build/build.ocp2
+++ b/tools/ocp-build/build.ocp2
@@ -94,6 +94,7 @@ begin
     "buildGlobals.ml";          (* All global variables and tables *)
     "buildConfig.ml";           (* Values stored in the configuration file. *)
     "buildUninstall.ml";
+    "buildDepMisc.ml";
   ];
 
   ocaml.requires = [ "ocplib-unix"; "ocp-build-engine"; "ocp-build-project";

--- a/tools/ocp-build/buildDepMisc.ml
+++ b/tools/ocp-build/buildDepMisc.ml
@@ -1,0 +1,181 @@
+(**************************************************************************)
+(*                                                                        *)
+(*   Typerex Tools                                                        *)
+(*                                                                        *)
+(*   Copyright 2011-2017 OCamlPro SAS                                     *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU General Public License version 3 described in the file       *)
+(*   LICENSE.                                                             *)
+(*                                                                        *)
+(**************************************************************************)
+
+open OcpCompat
+open BuildEngineTypes
+open BuildTypes
+open BuildOCPTypes
+open BuildValue.TYPES
+
+let verbose = OcpDebug.verbose_function [ "B" ;"BuildOCamldep" ]
+
+let parse_dependencies b =
+  let s = Buffer.contents b in
+  let len = String.length s in
+  let dependencies = ref [] in
+
+  let rec parse_name pos pos0 =
+(*    Printf.eprintf "parse_name %d %d\n%!" pos pos0; *)
+    if pos+1 < len && s.[pos] = ':' && s.[pos+1] = ' ' then
+      let target = String.sub s pos0 (pos-pos0) in
+      skip_spaces target [] (pos+1)
+    else
+      if pos+1 < len && s.[pos] = ':' && s.[pos+1] = '\n' then begin
+   let target = String.sub s pos0 (pos-pos0) in
+   dependencies := (target, []) :: !dependencies;
+   parse_name (pos+2) (pos+2)
+      end else
+   if pos = len then
+     !dependencies
+   else
+     parse_name (pos+1) pos0
+
+  and skip_spaces target deps pos =
+(*    Printf.eprintf "skip_spaces %d\n%!" pos; *)
+    if pos = len then
+      (target, deps) :: !dependencies
+    else
+      match s.[pos] with
+     '\\' when pos+1 < len && s.[pos+1] = '\n' ->
+       skip_spaces target deps (pos+2)
+   | ' ' ->
+     skip_spaces target deps (pos+1)
+   | '\n' ->
+     dependencies := (target, deps) :: !dependencies;
+     parse_name (pos+1) (pos+1)
+   | '\\' when pos + 1 < len && s.[pos+1] = ' ' ->
+     Buffer.clear b;
+     Buffer.add_char b ' ';
+     parse_dependency target deps (pos+2)
+   | c ->
+     Buffer.clear b;
+     Buffer.add_char b c;
+     parse_dependency target deps (pos+1)
+
+  and parse_dependency target deps pos =
+(*    Printf.eprintf "parse_dependency %d\n%!" pos; *)
+    if pos = len then
+      (target, (Buffer.contents b) :: deps) :: !dependencies
+    else
+      match s.[pos] with
+   | '\\' when pos + 1 < len && s.[pos+1] = ' ' ->
+     Buffer.add_char b ' ';
+     parse_dependency target deps (pos+2)
+   | ' ' ->
+     skip_spaces target ((Buffer.contents b) :: deps) (pos+1)
+   | '\n' ->
+     dependencies := (target,
+     (Buffer.contents b) :: deps) :: !dependencies;
+     parse_name (pos+1) (pos+1)
+   | c ->
+     Buffer.add_char b c;
+     parse_dependency target deps (pos+1)
+  in
+  parse_name 0 0
+
+
+       (* ocamldep generates dependencies towards .cmo files for
+          .cmi files, even in the case where we are only
+          interested in .cmx files !  Problem: if we add two
+          dependencies, one to .cmo and one to .cmx, then
+          rebuilding any of them will trigger regenerating the
+          .cmi, while in fact, only rebuilding both should
+          trigger the rebuilding.
+
+          In a general case, what should we do if there is a
+          dependency towards a bytecode file (in particular for
+          camlp4) when specifying native building ?
+
+          In fact, probably, we want to add the first active
+          dependency among a set of dependencies. So, the
+          dependency would not be a filename by a list of
+          filenames.
+       *)
+
+let expanse_dependencies list =
+  List.map (fun (target, deps) ->
+    if Filename.check_suffix target  ".cmi" then
+      (target,
+       List.map (fun dep ->
+           if Filename.check_suffix dep ".cmo" then
+             let cmx = Bytes.of_string dep in
+             cmx.[Bytes.length cmx - 1 ] <- 'x';
+             let cmx = Bytes.to_string cmx in
+             [ dep; cmx ]
+           else
+             [dep]
+         ) deps)
+    else
+      (target, List.map (fun dep -> [dep]) deps)
+    ) list
+
+(* load_dependencies: the old way, i.e. path to files in the load_path *)
+
+let parse_dep_buf = Buffer.create 10000
+let load_make_dependencies filename =
+  Buffer.clear parse_dep_buf;
+  let ic = open_in filename in
+  begin
+    try
+      while true do
+   let line = input_line ic in
+   Printf.bprintf parse_dep_buf "%s\n%!" line
+      done
+    with End_of_file -> ()
+  end;
+  close_in ic;
+  parse_dependencies parse_dep_buf
+
+(*
+let print_make_dependencies deps =
+  List.iter (fun (dep, deps) ->
+    Printf.eprintf "%s: " dep;
+    List.iter (fun x -> Printf.eprintf "%s " x ) deps;
+    Printf.eprintf "\n%!";
+  ) deps
+*)
+
+let load_make_dependencies filename =
+  try
+    let deps = load_make_dependencies filename in
+(*    print_make_dependencies deps; *)
+    deps
+  with e ->
+    Printf.eprintf "Warning: exception %s in load_make_dependencies\n%!"
+      (Printexc.to_string e);
+    raise e
+
+
+let load_dependencies filename =
+  expanse_dependencies (load_make_dependencies filename)
+
+
+(* Another solution:
+
+Use ocamldep -modules toto.ml
+
+When reading, we must keep track of what project this file belongs to.
+Then, we can infer from which projects the dependencies are
+*)
+
+let print_dependencies deps =
+  List.iter (fun (dep, deps) ->
+    Printf.eprintf "%s: " dep;
+    List.iter (fun list ->
+      match list with
+     [] -> ()
+   | [ x ] -> Printf.eprintf "%s " x
+   | [ x; y ] -> Printf.eprintf " (%s|%s) " x y
+   | _ -> assert false
+    ) deps;
+    Printf.eprintf "\n%!";
+  ) deps

--- a/tools/ocp-build/buildDepMisc.mli
+++ b/tools/ocp-build/buildDepMisc.mli
@@ -10,18 +10,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* [load_modules_dependencies filename] returns a list of association between
+(* [load_dependencies filename] returns a list of association between
  a target and a list of filenames, its dependencies. *)
-val load_modules_dependencies :
-  BuildOCamlTypes.ocaml_package -> BuildValue.TYPES.env ->
-  BuildOCamlTypes.force_kind ->
-  BuildEngineTypes.build_directory -> string list -> (* needs_odoc *) bool ->
-  string -> (string * string list list) list
+val load_dependencies : string -> (string * string list list) list
 
+val load_make_dependencies : string -> (string * string list) list
 
-val modname_of_file : BuildValue.TYPES.env list ->
-  BuildOCamlTypes.force_kind ->
-  string ->
-  bool * (* is_ml *)
-    string * (* modname *)
-    string   (* basename *)
+val print_dependencies : (string * string list list) list -> unit

--- a/tools/ocp-build/engine/buildEngine.ml
+++ b/tools/ocp-build/engine/buildEngine.ml
@@ -825,7 +825,7 @@ let add_dependency b r target_file filenames =
 let load_dependency_file b loader file r_ok =
   if verbose 7 then Printf.eprintf "Loading dependencies from %s\n%!" (file_filename file);
   begin try
-          let dependencies = (* BuildOcamldep.load_dependencies *) loader (file_filename file) in
+          let dependencies = loader (file_filename file) in
 
           List.iter (fun (filename, deps) ->
             if verbose 7 then Printf.eprintf "FILE %s\n%!" filename;

--- a/tools/ocp-build/ocaml/buildOCamlGlobals.ml
+++ b/tools/ocp-build/ocaml/buildOCamlGlobals.ml
@@ -85,11 +85,17 @@ in
       [file_ready]
   in
   let lib_meta = BuildValue.get_bool_with_default envs "meta" false in
-
+  let lib_alias =   BuildValue.get_string_option_with_default
+                      opk.opk_options "alias" None
+  in
+  let lib_aliases = StringMap.empty in
 
   let lib = {
     lib = lib;
     lib_opk = opk;
+
+    lib_alias;
+    lib_aliases;
 
     lib_autolink;
 

--- a/tools/ocp-build/ocaml/buildOCamlRules.ml
+++ b/tools/ocp-build/ocaml/buildOCamlRules.ml
@@ -87,6 +87,30 @@ let string_of_libloc lib =
 *)
 
 
+let open_aliases_flag = "open-aliases"
+let is_aliased options =
+  BuildValue.get_bool_with_default [options] open_aliases_flag  true
+
+let comp_alias_options lib options =
+  match lib.lib_alias with
+  | None -> []
+  | Some alias ->
+     let args = ["-w"; "-49"; "-no-alias-deps" ] in
+     if is_aliased options then
+       args @ [ "-open"; String.capitalize alias ]
+     else
+       args
+
+let dep_alias_options lib options =
+  match lib.lib_alias with
+  | None -> []
+  | Some alias ->
+     let args = [] in
+     if is_aliased options then
+       args @ [ "-open"; String.capitalize alias ]
+     else
+       args
+
 let ocamlc_command options ocamlc_specific ocamlc_generic =
   let ocamlc_command = ocamlc_specific.get options in
   if ocamlc_command = [] then
@@ -448,6 +472,7 @@ let add_ml2mldep_rule lib dst_dir pack_for force src_file target_file needs_odoc
   let cmd = new_command (ocamldep_cmd.get envs)
     (depflags envs) in
   add_command_string cmd "-modules";
+  add_command_strings cmd (dep_alias_options lib options);
   add_command_strings cmd (command_includes lib pack_for);
 (*  add_command_strings cmd (command_pp lib options); *)
   if force = Force_IMPL || ml_file_option.get envs  then
@@ -490,6 +515,7 @@ let add_ml2mldep_rule lib dst_dir pack_for force src_file target_file needs_odoc
   let loader =
     BuildOCamldep.load_modules_dependencies
       lib options force dst_dir pack_for needs_odoc
+      (* not fully applied *)
   in
   let r_loaded = new_rule lib mldep_file_loaded [] in
   add_rule_command r_loaded (LoadDeps (loader, target_file, r_loaded));
@@ -1121,6 +1147,12 @@ let add_mli_source w b lib ptmp mli_file options =
 
     let basename = mli_file.file_basename in
     let kernel_name = Filename.chop_extension basename in
+    let kernel_modalias = String.capitalize kernel_name in
+    let kernel_name = match lib.lib_alias with
+      | None -> kernel_name
+      | Some alias -> Printf.sprintf "%s__%s" alias kernel_modalias
+    in
+    let kernel_modname = String.capitalize kernel_name in
 
     let copy_objects_from = get_copy_objects_from lib envs  in
     match copy_objects_from with
@@ -1186,6 +1218,7 @@ let add_mli_source w b lib ptmp mli_file options =
           let cmd = new_command (ocamlc_cmd.get envs ) (bytecompflags envs) in
           add_bin_annot_argument cmd envs;
           add_command_args cmd [S "-c"; S "-o"; BF cmi_temp];
+          add_command_strings cmd (comp_alias_options lib options);
           add_command_strings cmd (command_includes lib pack_for);
           (*      add_command_strings cmd (command_pp lib options); *)
           if force = Force_INTF || mli_file_option.get envs  then
@@ -1196,6 +1229,7 @@ let add_mli_source w b lib ptmp mli_file options =
           let cmd = new_command (ocamlopt_cmd.get envs ) (asmcompflags envs) in
           add_bin_annot_argument cmd envs;
           add_command_args cmd [S "-c"; S "-o"; BF cmi_temp];
+          add_command_strings cmd (comp_alias_options lib options);
           add_command_strings cmd (command_includes lib pack_for);
           add_command_pack_args cmd pack_for;
           (*    add_command_strings cmd (command_pp lib options); *)
@@ -1212,7 +1246,8 @@ let add_mli_source w b lib ptmp mli_file options =
         cross_move r [ BF cmi_temp, BF cmi_file ];
         add_rule_temporary r cmi_temp;
       end;
-      move_compilation_garbage r copy_dir mli_file.file_dir.dir_file kernel_name lib;
+      move_compilation_garbage r copy_dir mli_file.file_dir.dir_file
+                               kernel_name lib;
       add_rule_source r mli_file;
       add_rule_sources r seq_order;
 
@@ -1231,22 +1266,35 @@ let add_mli_source w b lib ptmp mli_file options =
       in
 
       begin
+        let dep_info =
+        (*
         let (_is_ml, modname, basename) =
           BuildOCamldep.modname_of_file envs force mli_file.file_basename in
+         *)
         try
-          let (kind, basename) = StringMap.find modname !lib_modules in
+          let (kind, basename) = StringMap.find kernel_modname !lib_modules in
           match kind with
-            MLI -> ()
-          | MLandMLI -> ()
-          | ML ->
-            lib_modules := StringMap.add modname (MLandMLI, basename) !lib_modules
+            MLI
+          | MLandMLI -> None
+          | ML -> Some (MLandMLI, basename)
         with Not_found ->
-          if verbose 5 then
-            Printf.eprintf "Adding module %s to %s\n" modname lib.lib.lib_name;
-          lib_modules := StringMap.add modname (MLI, basename) !lib_modules
+          (* if verbose 5 then *)
+               Printf.eprintf "Adding MLI module %s to %s in %s\n"
+                              kernel_modname kernel_name lib.lib.lib_name;
+             Some (MLI, DepBasename kernel_name)
+        in
+        match dep_info with
+        | None -> ()
+        | Some (kind, basename) ->
+           lib_modules :=
+             StringMap.add kernel_modname (kind, basename) !lib_modules;
+           if kernel_modname <> kernel_modalias then
+             lib.lib_aliases <-
+               StringMap.add kernel_modalias (kind, basename) lib.lib_aliases
       end;
 
-      mli2odoc lib ptmp kernel_name envs pack_for force mli_file seq_order;
+      mli2odoc lib ptmp kernel_name
+               envs pack_for force mli_file seq_order;
 
       if pack_for = [] then
         ptmp.cmi_files := cmi_file :: !(ptmp.cmi_files)
@@ -1522,6 +1570,15 @@ let copy_mli_if_needed lib mut_dir mll_file kernel_name =
 (* Shall we infer the presence of the mli file ? We should probably ask the user
    to tell the build system that the mli does not exist. *)
 
+let content_generator new_file f =
+  function () ->
+           let b = Buffer.create 10000 in
+           f b;
+           let content = Buffer.contents b in
+           let file = file_filename new_file in
+           BuildEngineReport.cmd_file_from_content file content;
+           FileString.file_of_string file content;
+           ()
 
 let add_ml_source w b lib ptmp ml_file options =
   let needs_odoc = needs_odoc lib in
@@ -1529,9 +1586,20 @@ let add_ml_source w b lib ptmp ml_file options =
   let envs = options :: lib.lib_opk.opk_options in
   let basename = ml_file.file_basename in
   (*  Printf.eprintf "basename = [%s]\n" basename; *)
-  let kernel_name =
+  let kernel_alias =
     BuildValue.get_string_with_default envs "module"
-      (Filename.chop_extension basename) in
+                                       (Filename.chop_extension basename) in
+  let kernel_modalias = String.capitalize kernel_alias in
+  let kernel_name = match lib.lib_alias with
+    | None -> kernel_alias
+    | Some alias ->
+       if is_aliased options then
+         Printf.sprintf "%s__%s" alias kernel_modalias
+       else
+         kernel_alias
+  in
+
+  let kernel_modname = String.capitalize kernel_name in
 
   let has_byte = lib.lib_opk.opk_has_byte in
   let has_asm = lib.lib_opk.opk_has_asm in
@@ -1592,7 +1660,7 @@ let add_ml_source w b lib ptmp ml_file options =
             let mli_file = BuildValue.get_string envs mli_file_attr in
             Some (add_package_file lib mli_file, false)
           with Var_not_found _ ->
-            let mli_name = kernel_name ^ ".mli" in
+            let mli_name = kernel_alias ^ ".mli" in
             let mli_file =
               Filename.concat
                 orig_ml_file.file_dir.dir_fullname
@@ -1603,7 +1671,7 @@ let add_ml_source w b lib ptmp ml_file options =
               Some (add_file lib orig_ml_file.file_dir mli_name, true)
             else
               try
-                Some (find_dst_file lib.lib.lib_src_dir (kernel_name ^ ".mli"), true)
+                Some (find_dst_file lib.lib.lib_src_dir (kernel_alias ^ ".mli"), true)
               with NoSuchFileInDir _ -> None
       in
 
@@ -1626,19 +1694,15 @@ let add_ml_source w b lib ptmp ml_file options =
                           Printf.bprintf b "%s\n" file
                         ) sources
                       ),
-                      (fun () ->
-                        let b = Buffer.create 10000 in
+                      content_generator new_ml_file
+                      (fun b ->
                         Printf.bprintf b "let files = [\n";
                         List.iter (fun (file, src_file) ->
                           Printf.bprintf b "%S, %S;"
                             file (FileString.string_of_file (file_filename src_file))
                         ) sources;
                         Printf.bprintf b "  ]\n";
-                        let content = Buffer.contents b in
-                        let file = file_filename new_ml_file in
-                        BuildEngineReport.cmd_file_from_content file content;
-                        FileString.file_of_string file content;
-                        ())));
+                           )));
           new_ml_file
       in
 
@@ -1672,7 +1736,7 @@ let add_ml_source w b lib ptmp ml_file options =
         Printf.eprintf "Need to copy mli file for %S\n%!"
           (file_filename old_ml_file);
         *)
-          copy_mli_if_needed lib lib.lib.lib_mut_dir old_ml_file kernel_name;
+          copy_mli_if_needed lib lib.lib.lib_mut_dir old_ml_file kernel_alias;
       end;
 
 
@@ -1685,8 +1749,6 @@ let add_ml_source w b lib ptmp ml_file options =
       *)
 
 
-      let modname = String.capitalize kernel_name in
-
       let cmi_name = kernel_name ^ ".cmi" in
 
       (* TODO: we already check for this previously in _has_mli. Why not use
@@ -1698,7 +1760,7 @@ let add_ml_source w b lib ptmp ml_file options =
           let cmi_file = find_dst_file dst_dir cmi_name in
           Some cmi_file
         with NoSuchFileInDir _ ->
-          let mli_name = kernel_name ^ ".mli" in
+          let mli_name = kernel_alias ^ ".mli" in
           let mli_file =
             Filename.concat
               orig_ml_file.file_dir.dir_fullname
@@ -1711,7 +1773,7 @@ let add_ml_source w b lib ptmp ml_file options =
                 Some (add_file lib orig_ml_file.file_dir mli_name)
               else
                 try
-                  Some (find_dst_file lib.lib.lib_src_dir (kernel_name ^ ".mli"))
+                  Some (find_dst_file lib.lib.lib_src_dir (kernel_alias ^ ".mli"))
                 with NoSuchFileInDir _ -> None
             in
             match mli_file with
@@ -1727,14 +1789,16 @@ let add_ml_source w b lib ptmp ml_file options =
             None
       in
 
+      ptmp.src_files <- IntMap.add ml_file.file_id ml_file ptmp.src_files;
       let seq_order =
-        if pack_of <> [] then
+        if pack_of <> [] ||
+             (* do not compute dependencies for alias source *)
+        (lib.lib_alias <> None && not (is_aliased options)) then
           [] (* don't compute dependencies when we already know them *)
         else
           let mldep_file =
             add_dst_file lib dst_dir (kernel_name ^ ".mlmods")
           in
-          ptmp.src_files <- IntMap.add ml_file.file_id ml_file ptmp.src_files;
           let mldep_file_ok = add_ml2mldep_rule lib dst_dir pack_for force ml_file mldep_file
             (needs_odoc && needs_cmi = None) options in
           ptmp.dep_files <- IntMap.add mldep_file.file_id mldep_file ptmp.dep_files;
@@ -1760,23 +1824,35 @@ let add_ml_source w b lib ptmp ml_file options =
       in
 
       begin
+        (*
         let (_is_ml, modname, basename) = BuildOCamldep.modname_of_file envs force ml_file.file_basename in
-        try
-          let (kind, basename) =  StringMap.find modname !lib_modules in
-          let error filename =
-            Printf.eprintf
-              "ERROR: The file(s) %s appears more than once in %s\n%!"
-              filename
-              lib.lib.lib_filename in
-          match kind with
-            ML       -> error (basename ^ ".ml")
-          | MLandMLI -> error (basename ^ ".ml and " ^ basename ^ ".mli")
-          | MLI ->
-            lib_modules := StringMap.add modname (MLandMLI, basename) !lib_modules
-        with Not_found ->
-          if verbose 5 then
-            Printf.eprintf "Adding module %s to %s\n" modname lib.lib.lib_name;
-          lib_modules := StringMap.add modname (ML, basename) !lib_modules
+         *)
+        let dep =
+          try
+            let (kind, basename) =  StringMap.find kernel_modname !lib_modules
+            in
+            match kind with
+              ML
+            | MLandMLI -> None
+            | MLI -> Some (MLandMLI, basename)
+          with Not_found ->
+            (* if verbose 5 then *)
+                 Printf.eprintf "Adding ML module %s to %s.CMO in %s\n"
+                                kernel_modname kernel_name lib.lib.lib_name;
+               Some (ML, DepBasename kernel_name)
+        in
+        match dep with
+        | None ->
+           Printf.eprintf
+             "ERROR: The file(s) %s appears more than once in %s\n%!"
+             (kernel_name ^ ".ml")
+             lib.lib.lib_filename
+        | Some (kind, basename) ->
+           lib_modules := StringMap.add kernel_modname (kind, basename)
+                                        !lib_modules;
+           if kernel_modname <> kernel_modalias then
+             lib.lib_aliases <-
+               StringMap.add kernel_modalias (kind, basename) lib.lib_aliases
       end;
 
 
@@ -1810,7 +1886,8 @@ let add_ml_source w b lib ptmp ml_file options =
 
 
           if pack_of = [] then begin
-            add_command_args cmd [S "-c"; S "-o"; T cmo_basename];
+              add_command_args cmd [S "-c"; S "-o"; T cmo_basename];
+              add_command_strings cmd (comp_alias_options lib options);
             add_command_pack_args cmd pack_for;
             add_command_strings cmd (command_includes lib pack_for);
             (*      add_command_strings cmd (command_pp ptmp options); *)
@@ -1824,7 +1901,7 @@ let add_ml_source w b lib ptmp ml_file options =
             add_command_args cmd [S "-pack"; S "-o"; T cmo_basename];
             add_command_pack_args cmd pack_for;
 
-            let src_dir = Filename.concat dst_dir.dir_fullname modname in
+            let src_dir = Filename.concat dst_dir.dir_fullname kernel_modname in
             (*      Printf.eprintf "Pack in %s [%s]\n" src_dir modname; *)
             let src_dir = BuildEngineContext.add_directory b src_dir in
             let cmo_files = get_packed_objects lib r src_dir pack_of "cmo" in
@@ -1877,7 +1954,8 @@ let add_ml_source w b lib ptmp ml_file options =
           *)
 
           if pack_of = [] then begin
-            add_command_args cmd [S "-c"; S "-o"; T cmx_basename];
+              add_command_args cmd [S "-c"; S "-o"; T cmx_basename];
+              add_command_strings cmd (comp_alias_options lib options);
             add_command_pack_args cmd pack_for;
             add_command_strings cmd (command_includes lib pack_for);
             (*      add_command_strings cmd (command_pp ptmp options); *)
@@ -1891,7 +1969,7 @@ let add_ml_source w b lib ptmp ml_file options =
             add_command_args cmd [S "-pack"; S "-o"; T cmx_basename];
             add_command_pack_args cmd pack_for;
 
-            let src_dir = BuildEngineContext.add_directory b (Filename.concat dst_dir.dir_fullname modname) in
+            let src_dir = BuildEngineContext.add_directory b (Filename.concat dst_dir.dir_fullname kernel_modname) in
             let cmx_files = get_packed_objects lib r src_dir pack_of "cmx" in
             let cmd = add_files_to_link_to_command lib "asm pack" cmd envs cmx_files in
             add_rule_command r cmd
@@ -2157,6 +2235,51 @@ let process_sources w b lib =
     | ObjectsPackage ->
       let src_dir = lib.lib.lib_src_dir in
       let _dst_dir = lib.lib.lib_dst_dir in
+
+      begin
+        match lib.lib_alias with
+        | None -> ()
+        | Some alias ->
+           let alias_file = add_file lib lib.lib.lib_dst_dir (alias ^ ".ml") in
+
+
+           let r = new_rule lib alias_file [] in
+           let modnames =
+             List.fold_left (fun acc (filename, options) ->
+                 let (is_ml, modname, _basename) =
+                   BuildOCamldep.modname_of_file [options] Force_not filename
+                 in
+                 if is_ml then modname :: acc else acc
+               ) [] lib.lib_sources
+           in
+           let mod_alias = String.capitalize alias in
+           add_rule_command r (
+                              Function ("gen-alias",
+                                        (fun b ->
+                                          List.iter (fun s ->
+                                              Buffer.add_string b s;
+                                              Buffer.add_char b '|'
+                                            ) modnames
+                                        ),
+                                        content_generator alias_file
+                                        (fun b ->
+                                          List.iter (fun s ->
+                                              Printf.bprintf b
+                                                             "module %s = %s__%s\n"
+                                                             s
+                                                             mod_alias
+                                                             s
+
+                                            ) modnames;
+
+                                        )
+                            ));
+           (* TODO: how to add specific options here ? *)
+           let options = BuildValue.empty_env in
+           let options = BuildValue.set_bool options open_aliases_flag false in
+           add_ml_source w b lib ptmp alias_file options
+      end;
+
       List.iter (process_source w b lib ptmp src_dir) lib.lib_sources;
   end;
 
@@ -2400,7 +2523,7 @@ let add_extra_rules bc lib target_name target_files =
 
           let loader filename =
             let dependencies =
-              BuildOCamldep.load_make_dependencies filename
+              BuildDepMisc.load_make_dependencies filename
             in
             List.map (fun (file, deps) ->
               (Filename.concat dirname_s file,
@@ -2812,14 +2935,16 @@ let create w cin cout bc state =
              try
              match StringMap.find modname !map with
              | (ML, _) when not is_ml ->
-               map := StringMap.add modname (MLandMLI, basename) !map
+                map := StringMap.add modname
+                                     (MLandMLI, DepBasename basename) !map
              | (MLI, _) when is_ml ->
-               map := StringMap.add modname (MLandMLI, basename) !map
+                map := StringMap.add modname
+                                     (MLandMLI, DepBasename basename) !map
              | (MLandMLI, _) -> ()
              | _ -> raise Not_found
              with Not_found ->
                map := StringMap.add modname (
-                 (if is_ml then ML else MLI), basename) !map
+                 (if is_ml then ML else MLI), DepBasename basename) !map
           ) objs;
           lib.lib_modules <- !dirs
       end;

--- a/tools/ocp-build/ocaml/buildOCamlTypes.ml
+++ b/tools/ocp-build/ocaml/buildOCamlTypes.ml
@@ -55,12 +55,16 @@ type ocaml_package = {
   lib : BuildTypes.package_info;
   lib_opk : ocaml_description;
 
+  mutable lib_alias : string option;
+  mutable lib_aliases :
+            (module_origin * ocaml_dep) StringMap.t;
+
   mutable lib_modules :
     (BuildEngineTypes.build_directory *
-       (module_origin * string) StringMap.t ref) list;
+       (module_origin * ocaml_dep) StringMap.t ref) list;
   mutable lib_internal_modules :
     (BuildEngineTypes.build_directory *
-       (module_origin * string)
+       (module_origin * ocaml_dep)
         StringMap.t ref) StringsMap.t;
 
   lib_build_targets : BuildEngineTypes.build_file list ref;
@@ -68,6 +72,7 @@ type ocaml_package = {
   lib_test_targets : BuildEngineTypes.build_file list ref;
 
   mutable lib_autolink : bool;
+
 
   mutable lib_byte_targets : (BuildEngineTypes.build_file * target_kind) list;
   mutable lib_asm_targets : (BuildEngineTypes.build_file * target_kind) list;
@@ -88,6 +93,10 @@ type ocaml_package = {
   mutable lib_ready : BuildEngineTypes.build_file list;
   mutable lib_meta : bool;
 }
+
+and ocaml_dep =
+  | DepBasename of string
+  | DepAlias of ocaml_package
 
 and ocaml_description = {
   opk_name : string;

--- a/tools/ocp-build/ocaml/buildOCamlTypes.mli
+++ b/tools/ocp-build/ocaml/buildOCamlTypes.mli
@@ -51,15 +51,19 @@ type ocaml_package = {
   lib : BuildTypes.package_info;
   lib_opk : ocaml_description;
 
+  mutable lib_alias : string option;
+  mutable lib_aliases :
+            (module_origin * ocaml_dep) StringMap.t;
+
   (* external modules to resolve dependencies externally. *)
   mutable lib_modules :
     (BuildEngineTypes.build_directory *
-       (module_origin * string) StringMap.t ref) list;
+       (module_origin * ocaml_dep) StringMap.t ref) list;
 
   (* modules map to resolve dependencies internally *)
   mutable lib_internal_modules :
     (BuildEngineTypes.build_directory *
-       (module_origin * string)
+       (module_origin * ocaml_dep)
         StringMap.t ref) StringsMap.t;
 
   (* Generic targets from generic rules *)
@@ -100,6 +104,10 @@ type ocaml_package = {
   mutable lib_ready : BuildEngineTypes.build_file list;
   mutable lib_meta : bool;
 }
+
+and ocaml_dep =
+  | DepBasename of string
+  | DepAlias of ocaml_package
 
 and ocaml_description = {
   opk_name : string;

--- a/tools/ocp-build/ocaml/buildOCamldep.ml
+++ b/tools/ocp-build/ocaml/buildOCamldep.ml
@@ -20,169 +20,6 @@ open BuildValue.TYPES
 
 let verbose = OcpDebug.verbose_function [ "B" ;"BuildOCamldep" ]
 
-let parse_dependencies b =
-  let s = Buffer.contents b in
-  let len = String.length s in
-  let dependencies = ref [] in
-
-  let rec parse_name pos pos0 =
-(*    Printf.eprintf "parse_name %d %d\n%!" pos pos0; *)
-    if pos+1 < len && s.[pos] = ':' && s.[pos+1] = ' ' then
-      let target = String.sub s pos0 (pos-pos0) in
-      skip_spaces target [] (pos+1)
-    else
-      if pos+1 < len && s.[pos] = ':' && s.[pos+1] = '\n' then begin
-   let target = String.sub s pos0 (pos-pos0) in
-   dependencies := (target, []) :: !dependencies;
-   parse_name (pos+2) (pos+2)
-      end else
-   if pos = len then
-     !dependencies
-   else
-     parse_name (pos+1) pos0
-
-  and skip_spaces target deps pos =
-(*    Printf.eprintf "skip_spaces %d\n%!" pos; *)
-    if pos = len then
-      (target, deps) :: !dependencies
-    else
-      match s.[pos] with
-     '\\' when pos+1 < len && s.[pos+1] = '\n' ->
-       skip_spaces target deps (pos+2)
-   | ' ' ->
-     skip_spaces target deps (pos+1)
-   | '\n' ->
-     dependencies := (target, deps) :: !dependencies;
-     parse_name (pos+1) (pos+1)
-   | '\\' when pos + 1 < len && s.[pos+1] = ' ' ->
-     Buffer.clear b;
-     Buffer.add_char b ' ';
-     parse_dependency target deps (pos+2)
-   | c ->
-     Buffer.clear b;
-     Buffer.add_char b c;
-     parse_dependency target deps (pos+1)
-
-  and parse_dependency target deps pos =
-(*    Printf.eprintf "parse_dependency %d\n%!" pos; *)
-    if pos = len then
-      (target, (Buffer.contents b) :: deps) :: !dependencies
-    else
-      match s.[pos] with
-   | '\\' when pos + 1 < len && s.[pos+1] = ' ' ->
-     Buffer.add_char b ' ';
-     parse_dependency target deps (pos+2)
-   | ' ' ->
-     skip_spaces target ((Buffer.contents b) :: deps) (pos+1)
-   | '\n' ->
-     dependencies := (target,
-     (Buffer.contents b) :: deps) :: !dependencies;
-     parse_name (pos+1) (pos+1)
-   | c ->
-     Buffer.add_char b c;
-     parse_dependency target deps (pos+1)
-  in
-  parse_name 0 0
-
-
-       (* ocamldep generates dependencies towards .cmo files for
-          .cmi files, even in the case where we are only
-          interested in .cmx files !  Problem: if we add two
-          dependencies, one to .cmo and one to .cmx, then
-          rebuilding any of them will trigger regenerating the
-          .cmi, while in fact, only rebuilding both should
-          trigger the rebuilding.
-
-          In a general case, what should we do if there is a
-          dependency towards a bytecode file (in particular for
-          camlp4) when specifying native building ?
-
-          In fact, probably, we want to add the first active
-          dependency among a set of dependencies. So, the
-          dependency would not be a filename by a list of
-          filenames.
-       *)
-
-let expanse_dependencies list =
-  List.map (fun (target, deps) ->
-    if Filename.check_suffix target  ".cmi" then
-      (target, List.map (fun dep ->
-
-   if Filename.check_suffix target ".cmo" then
-     let cmx = Bytes.of_string dep in
-     cmx.[Bytes.length cmx - 1 ] <- 'x';
-     let cmx = Bytes.to_string cmx in
-     [ dep; cmx ]
-   else
-     [dep]
-       ) deps)
-    else
-      (target, List.map (fun dep -> [dep]) deps)
-  ) list
-
-(* load_dependencies: the old way, i.e. path to files in the load_path *)
-
-let parse_dep_buf = Buffer.create 10000
-let load_make_dependencies filename =
-  Buffer.clear parse_dep_buf;
-  let ic = open_in filename in
-  begin
-    try
-      while true do
-   let line = input_line ic in
-   Printf.bprintf parse_dep_buf "%s\n%!" line
-      done
-    with End_of_file -> ()
-  end;
-  close_in ic;
-  parse_dependencies parse_dep_buf
-
-(*
-let print_make_dependencies deps =
-  List.iter (fun (dep, deps) ->
-    Printf.eprintf "%s: " dep;
-    List.iter (fun x -> Printf.eprintf "%s " x ) deps;
-    Printf.eprintf "\n%!";
-  ) deps
-*)
-
-let load_make_dependencies filename =
-  try
-    let deps = load_make_dependencies filename in
-(*    print_make_dependencies deps; *)
-    deps
-  with e ->
-    Printf.eprintf "Warning: exception %s in load_make_dependencies\n%!"
-      (Printexc.to_string e);
-    raise e
-
-
-let load_dependencies filename =
-  expanse_dependencies (load_make_dependencies filename)
-
-
-(* Another solution:
-
-Use ocamldep -modules toto.ml
-
-When reading, we must keep track of what project this file belongs to.
-Then, we can infer from which projects the dependencies are
-*)
-
-let print_dependencies deps =
-  List.iter (fun (dep, deps) ->
-    Printf.eprintf "%s: " dep;
-    List.iter (fun list ->
-      match list with
-     [] -> ()
-   | [ x ] -> Printf.eprintf "%s " x
-   | [ x; y ] -> Printf.eprintf " (%s|%s) " x y
-   | _ -> assert false
-    ) deps;
-    Printf.eprintf "\n%!";
-  ) deps
-
-
 let load_ocamldep_modules filename =
   let ic = open_in filename in
   let s = input_line ic in
@@ -200,6 +37,8 @@ let modname_of_file options force filename =
   let filename = Filename.basename filename in
   let is_ml =
     Filename.check_suffix filename ".ml"
+    || Filename.check_suffix filename ".mll"
+    || Filename.check_suffix filename ".mly"
     || Filename.check_suffix filename ".cmx"
     || Filename.check_suffix filename ".cmo"
     || force = Force_IMPL
@@ -239,12 +78,14 @@ let load_modules_dependencies lib options force dst_dir pack_for needs_odoc file
 
   let (is_ml, _modname, basename) = modname_of_file envs force source in
 
+  let basename = Filename.chop_extension (Filename.basename filename) in
+
   let modules =
     if not is_ml || nointernaldeps.get envs then modules
     else
-      "CamlinterlLazy" ::
-        "CamlinterlOO" ::
-        "CamlinterlMod" ::
+      "CamlinternalLazy" ::
+        "CamlinternalOO" ::
+        "CamlinternalMod" ::
         modules
   in
 
@@ -260,7 +101,8 @@ let load_modules_dependencies lib options force dst_dir pack_for needs_odoc file
          [dep.dep_options] "externals_only" false) then
       olib.lib_modules
     else []
-  ) (List.rev deps)) in
+                            ) (List.rev deps)) in
+  let deps = (lib.lib.lib_dst_dir, ref lib.lib_aliases) :: deps in
   let rec add_internal_deps pack_for deps =
     let deps =
       match pack_for with
@@ -307,11 +149,14 @@ let load_modules_dependencies lib options force dst_dir pack_for needs_odoc file
       | (dst_dir, lib_modules) :: deps ->
         try
           let (kind, basename) = StringMap.find depname !lib_modules in
+          match basename with
+          | DepAlias _lib -> assert false
+          | DepBasename basename ->
           let dst_dir = dst_dir.dir_fullname in
           let full_basename = Filename.concat dst_dir basename in
           match kind with
           | ML ->
-            (*
+             (*
             let deps = [] in
             let deps = if has_asm then
                 (full_basename ^ ".cmx") :: deps else deps
@@ -320,12 +165,12 @@ let load_modules_dependencies lib options force dst_dir pack_for needs_odoc file
                 (full_basename ^ ".cmo") :: deps else deps
             in
             *)
-            let deps = [full_basename ^ ".cmo"; full_basename ^ ".cmx" ] in
-            dependencies := deps :: !dependencies
+             let deps = [full_basename ^ ".cmo"; full_basename ^ ".cmx" ] in
+             dependencies := deps :: !dependencies
           | MLI ->
-            dependencies := [ full_basename ^ ".cmi" ] :: !dependencies
+             dependencies := [ full_basename ^ ".cmi" ] :: !dependencies
           | MLandMLI ->
-            dependencies := [ full_basename ^ ".cmi" ] :: !dependencies
+             dependencies := [ full_basename ^ ".cmi" ] :: !dependencies
 
         with Not_found ->
           find_module deps depname
@@ -358,18 +203,22 @@ let load_modules_dependencies lib options force dst_dir pack_for needs_odoc file
               | (dst_dir, lib_modules) :: deps ->
                 try
                   let (kind, basename) = StringMap.find depname !lib_modules in
-                  let dst_dir = dst_dir.dir_fullname in
-                  let full_basename = Filename.concat dst_dir basename in
-                  let deps =
-                    match kind with
-                    | ML ->
-                      [ full_basename ^ ".cmo" ]
-                    | MLI ->
-                      [ full_basename ^ ".cmi" ]
+                  match basename with
+                  | DepAlias _lib ->
+                     assert false
+                  | DepBasename basename ->
+                     let dst_dir = dst_dir.dir_fullname in
+                     let full_basename = Filename.concat dst_dir basename in
+                     let deps =
+                       match kind with
+                       | ML ->
+                          [ full_basename ^ ".cmo" ]
+                       | MLI ->
+                          [ full_basename ^ ".cmi" ]
                     | MLandMLI ->
-                      [ full_basename ^ ".cmi" ]
-                  in
-                  cmo_dependencies := deps :: !cmo_dependencies
+                       [ full_basename ^ ".cmi" ]
+                     in
+                     cmo_dependencies := deps :: !cmo_dependencies
                 with Not_found ->
                   find_module deps depname
             in
@@ -397,6 +246,9 @@ let load_modules_dependencies lib options force dst_dir pack_for needs_odoc file
               | (dst_dir, lib_modules) :: deps ->
                 try
                   let (kind, basename) = StringMap.find depname !lib_modules in
+                  match basename with
+                  | DepAlias _lib -> assert false
+                  | DepBasename basename ->
                   let src_dir = dst_dir.dir_fullname in
                   let full_basename = Filename.concat src_dir basename in
                   let deps =
@@ -432,5 +284,5 @@ let load_modules_dependencies lib options force dst_dir pack_for needs_odoc file
   if verbose 5 then
     Printf.eprintf "load_modules_dependencies %s DONE\n" filename;
   if verbose 3 then
-    print_dependencies dependencies;
+    BuildDepMisc.print_dependencies dependencies;
   dependencies


### PR DESCRIPTION
Projects can be compiled à la jbuilder:
```
OCaml.library("lib-perso", ocaml + {
      alias = "Perso";
      files = '[ x.ml y.ml z.ml ];
      requires = '[ lib1 lib2 ];
   });
```
