### PR TITLE
Better handle ocamlfind subpackages in optional deps

### DIFF
--- a/tools/ocp-autoconf/autoconfAutoconf.ml
+++ b/tools/ocp-autoconf/autoconfAutoconf.ml
@@ -121,6 +121,7 @@ let () =
          for i = 0 to Bytes.length package -1 do
            match Bytes.get package i with
            | '-' -> Bytes.set package i '_'
+           | '.' -> Bytes.set package i '_'
            | _ -> ()
          done;
          Bytes.to_string package


### PR DESCRIPTION
When an ocamlfind subpackage is used as optional dep, ocp-autoconf tries and generate a configure variables named `package_ENABLED`. However, for ocamlfind subpackages, e.g. `lablgtk2.sourceview2`, this results in invalid configure variable names due to the dot. This PR thus replaces dots by underscores.
Note: this might introduce name collisions if both a subpackage `foo.bar` **and** an ocamlfind package `foo_bar` exists, but it doesn't seem a likely occurrence.