### PR TITLE
OCaml 4.11 support

### DIFF
--- a/tools/ocp-pp/compat/4.11.0/ocpp_version.ml
+++ b/tools/ocp-pp/compat/4.11.0/ocpp_version.ml
@@ -1,0 +1,110 @@
+(**************************************************************************)
+(*                                                                        *)
+(*   Typerex Tools                                                        *)
+(*                                                                        *)
+(*   Copyright 2011-2017 OCamlPro SAS                                     *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU General Public License version 3 described in the file       *)
+(*   LICENSE.                                                             *)
+(*                                                                        *)
+(**************************************************************************)
+
+module OcpCompat = struct
+
+  module Bytes = Bytes
+  module Buffer = Buffer
+
+  module String = struct
+    include String
+    let set = Bytes.set
+  end
+
+end
+
+module StringSet = Set.Make(String)
+
+module StringMap = struct
+  module M = Map.Make(String)
+  include M
+  let of_list list =
+    let map = ref empty in
+    List.iter (fun (x,y) -> map := add x y !map) list;
+    !map
+
+  let to_list map =
+    let list = ref [] in
+    iter (fun x y -> list := (x,y) :: !list) map;
+    List.rev !list
+
+  let to_list_of_keys map =
+    let list = ref [] in
+    iter (fun x _y -> list := x :: !list) map;
+    List.rev !list
+end
+
+module Compat = struct
+
+  let with_location_error ppf f =
+    try
+      f ()
+    with x ->
+      Location.report_exception ppf x;
+      exit 2
+
+  open Parser
+
+  let mk_string s = STRING (s,Location.none,None)
+  let get_STRING = function
+    | STRING (s,_,_) -> s
+    | _ -> assert false
+
+  let name_of_token = function
+    | LBRACKETPERCENT|LBRACKETPERCENTPERCENT
+    | LBRACKETAT|LBRACKETATAT|LBRACKETATATAT|PERCENT|PLUSEQ -> "4.02.1 token"
+    | STRING (s,_,_) -> Printf.sprintf "STRING(%S,_)" s
+    | INT (int, s) -> Printf.sprintf "INT(%s,%s)" int
+      (match s with None -> "None" | Some c -> Printf.sprintf "Some %c" c)
+    | FLOAT (float, s) -> Printf.sprintf "FLOAT(%s,%s)" float
+      (match s with None -> "None" | Some c -> Printf.sprintf "Some %c" c)
+    | HASH -> "HASH"
+    | _  -> assert false
+
+  let string_of_token = function
+    | LBRACKETPERCENT|LBRACKETPERCENTPERCENT
+    | LBRACKETAT|LBRACKETATAT|LBRACKETATATAT|PERCENT|PLUSEQ -> "4.02.1 token"
+    | STRING (s,_,_) -> Printf.sprintf "%S" s
+    | INT (int, s) -> Printf.sprintf "%s%s" int
+      (match s with None -> "" | Some c -> Printf.sprintf "%c" c)
+    | FLOAT (float, s) -> Printf.sprintf "%s%s" float
+      (match s with None -> "" | Some c -> Printf.sprintf "%c" c)
+    | NONREC -> "nonrec"
+    | HASHOP op -> Printf.sprintf "hashop(%S)" op
+    | DOCSTRING _docstring -> "docstring _"
+    | HASH -> "#"
+    | _  -> assert false
+
+  let is_sharp = function
+    | HASH -> true
+    | _ -> false
+
+  let int_of_token = function
+    | INT (n, None) -> int_of_string n
+    | _ -> assert false
+  let token_of_int n = INT (string_of_int n, None)
+
+  let loc_of_token lexbuf token =
+    match token with
+    | COMMENT (_, loc) -> loc
+    | DOCSTRING doc -> Docstrings.docstring_loc doc
+    | _ -> Location.curr lexbuf
+
+  let find_in_load_path filename = Load_path.find filename
+
+  let add_to_load_path s = Load_path.add_dir s
+end
+
+module Location = struct
+  include Location
+  let print = print_loc
+end

--- a/tools/ocp-pp/ocpp.ml
+++ b/tools/ocp-pp/ocpp.ml
@@ -57,9 +57,8 @@ type state =
 
 type stack = (state * bool) list
 
-let token_of_token = function
-  | STRING (s,_) -> Ocpp_parser.STRING s
-  | _ -> assert false
+let token_of_token tok =
+  Ocpp_parser.STRING (Compat.get_STRING tok)
 
 let lines_of_file filename =
   let ic = open_in filename in


### PR DESCRIPTION
ocp-pp is currently not compatible with OCaml 4.11. This PR fixes this issue.

Note: the `ocpp_version.ml` file was copied from the `tools/ocp-pp/compat/4.08.0` directory, then modified with the changes according to the new AST from OCaml 4.11.

This PR is required to get `ocp-index` in OCaml 4.11.